### PR TITLE
fix: retry on stale CSRF token for all write operations

### DIFF
--- a/wiki/client.go
+++ b/wiki/client.go
@@ -837,6 +837,15 @@ func (c *Client) getCSRFToken(ctx context.Context) (string, error) {
 	return csrfToken, nil
 }
 
+// invalidateCSRFToken clears the cached CSRF token so the next write
+// operation fetches a fresh one. MediaWiki can invalidate CSRF tokens
+// after use, so we must not reuse them across edit requests.
+func (c *Client) invalidateCSRFToken() {
+	c.mu.Lock()
+	c.csrfToken = ""
+	c.mu.Unlock()
+}
+
 // EnsureLoggedIn ensures the client is logged in (for wikis requiring auth for read)
 func (c *Client) EnsureLoggedIn(ctx context.Context) error {
 	c.mu.RLock()

--- a/wiki/client_test.go
+++ b/wiki/client_test.go
@@ -519,6 +519,23 @@ func TestResetCookies(t *testing.T) {
 	}
 }
 
+func TestInvalidateCSRFToken(t *testing.T) {
+	client := createTestClient(t)
+	defer client.Close()
+
+	// Set a cached token
+	client.csrfToken = "cached-token"
+	client.tokenExpiry = time.Now().Add(time.Hour)
+
+	// Invalidate
+	client.invalidateCSRFToken()
+
+	// Token should be cleared, but expiry is untouched (next getCSRFToken will fetch fresh)
+	if client.csrfToken != "" {
+		t.Errorf("Expected csrfToken to be empty, got %q", client.csrfToken)
+	}
+}
+
 func TestEnsureLoggedIn_AlreadyLoggedIn(t *testing.T) {
 	client := createTestClient(t)
 	defer client.Close()

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -49,6 +49,19 @@ If you want to clear a page, use a single space or redirect instead.`,
 		return EditResult{}, err
 	}
 
+	editResult, err := c.performEdit(ctx, args)
+	if err != nil && strings.Contains(err.Error(), "badtoken") {
+		c.invalidateCSRFToken()
+		editResult, err = c.performEdit(ctx, args)
+	}
+	if err != nil {
+		return EditResult{}, err
+	}
+	return editResult, nil
+}
+
+// performEdit executes a single edit attempt with a fresh CSRF token.
+func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult, error) {
 	token, err := c.getCSRFToken(ctx)
 	if err != nil {
 		return EditResult{}, fmt.Errorf("authentication failed: %w", err)
@@ -79,6 +92,13 @@ If you want to clear a page, use a single space or redirect instead.`,
 	resp, err := c.apiRequest(ctx, params)
 	if err != nil {
 		return EditResult{}, err
+	}
+
+	// Check for API-level errors (badtoken, etc.)
+	if errInfo, ok := resp["error"].(map[string]interface{}); ok {
+		code := getString(errInfo["code"])
+		info := getString(errInfo["info"])
+		return EditResult{}, fmt.Errorf("%s: %s", code, info)
 	}
 
 	edit, ok := resp["edit"].(map[string]interface{})
@@ -539,20 +559,10 @@ func (c *Client) UploadFile(ctx context.Context, args UploadFileArgs) (UploadFil
 		return UploadFileResult{}, fmt.Errorf("authentication required for uploads: %w", err)
 	}
 
-	// Get CSRF token
-	token, err := c.getCSRFToken(ctx)
-	if err != nil {
-		return UploadFileResult{}, fmt.Errorf("failed to get edit token: %w", err)
-	}
-
-	var result UploadFileResult
-
-	// If URL provided, use URL upload
-	if args.FileURL != "" {
-		result, err = c.uploadFromURL(ctx, args, token)
-	} else {
-		// For local file upload, we need multipart form
-		result, err = c.uploadFromFile(ctx, args, token)
+	result, err := c.performUpload(ctx, args)
+	if err != nil && strings.Contains(err.Error(), "badtoken") {
+		c.invalidateCSRFToken()
+		result, err = c.performUpload(ctx, args)
 	}
 
 	// Log upload attempt (even if error occurred)
@@ -590,6 +600,19 @@ func (c *Client) UploadFile(ctx context.Context, args UploadFileArgs) (UploadFil
 	})
 
 	return result, nil
+}
+
+// performUpload executes a single upload attempt with a fresh CSRF token.
+func (c *Client) performUpload(ctx context.Context, args UploadFileArgs) (UploadFileResult, error) {
+	token, err := c.getCSRFToken(ctx)
+	if err != nil {
+		return UploadFileResult{}, fmt.Errorf("failed to get edit token: %w", err)
+	}
+
+	if args.FileURL != "" {
+		return c.uploadFromURL(ctx, args, token)
+	}
+	return c.uploadFromFile(ctx, args, token)
 }
 
 // uploadFromURL uploads a file from a URL
@@ -856,28 +879,11 @@ func (c *Client) downloadFile(ctx context.Context, fileURL string) ([]byte, erro
 	return data, nil
 }
 
-// MovePage moves (renames) a wiki page
-func (c *Client) MovePage(ctx context.Context, args MovePageArgs) (MovePageResult, error) {
-	if args.From == "" {
-		return MovePageResult{}, &ValidationError{
-			Field:   "from",
-			Message: "source page title is required",
-		}
-	}
-	if args.To == "" {
-		return MovePageResult{}, &ValidationError{
-			Field:   "to",
-			Message: "target page title is required",
-		}
-	}
-
-	if err := c.EnsureLoggedIn(ctx); err != nil {
-		return MovePageResult{}, fmt.Errorf("authentication required for page moves: %w", err)
-	}
-
+// performMove executes a single move attempt with a fresh CSRF token.
+func (c *Client) performMove(ctx context.Context, args MovePageArgs) (map[string]interface{}, error) {
 	token, err := c.getCSRFToken(ctx)
 	if err != nil {
-		return MovePageResult{}, fmt.Errorf("authentication failed: %w", err)
+		return nil, fmt.Errorf("authentication failed: %w", err)
 	}
 
 	params := url.Values{}
@@ -906,6 +912,45 @@ func (c *Client) MovePage(ctx context.Context, args MovePageArgs) (MovePageResul
 	}
 
 	resp, err := c.apiRequest(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for badtoken error so caller can retry
+	if errInfo, ok := resp["error"].(map[string]interface{}); ok {
+		code := getString(errInfo["code"])
+		if code == "badtoken" {
+			return nil, fmt.Errorf("%s: %s", code, getString(errInfo["info"]))
+		}
+	}
+
+	return resp, nil
+}
+
+// MovePage moves (renames) a wiki page
+func (c *Client) MovePage(ctx context.Context, args MovePageArgs) (MovePageResult, error) {
+	if args.From == "" {
+		return MovePageResult{}, &ValidationError{
+			Field:   "from",
+			Message: "source page title is required",
+		}
+	}
+	if args.To == "" {
+		return MovePageResult{}, &ValidationError{
+			Field:   "to",
+			Message: "target page title is required",
+		}
+	}
+
+	if err := c.EnsureLoggedIn(ctx); err != nil {
+		return MovePageResult{}, fmt.Errorf("authentication required for page moves: %w", err)
+	}
+
+	resp, err := c.performMove(ctx, args)
+	if err != nil && strings.Contains(err.Error(), "badtoken") {
+		c.invalidateCSRFToken()
+		resp, err = c.performMove(ctx, args)
+	}
 	if err != nil {
 		return MovePageResult{}, err
 	}

--- a/wiki/write_test.go
+++ b/wiki/write_test.go
@@ -248,6 +248,60 @@ func TestEditPage_EditFailed(t *testing.T) {
 	}
 }
 
+func TestEditPage_BadTokenRetry(t *testing.T) {
+	attempts := 0
+	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		action := r.FormValue("action")
+		if action == "edit" {
+			attempts++
+			if attempts == 1 {
+				// First attempt: return badtoken error
+				response := map[string]interface{}{
+					"error": map[string]interface{}{
+						"code": "badtoken",
+						"info": "Invalid CSRF token",
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+				return
+			}
+			// Second attempt: succeed
+			response := map[string]interface{}{
+				"edit": map[string]interface{}{
+					"result":   "Success",
+					"pageid":   float64(123),
+					"title":    "Test Page",
+					"newrevid": float64(456),
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	result, err := client.EditPage(context.Background(), EditPageArgs{
+		Title:   "Test Page",
+		Content: "Content",
+	})
+	if err != nil {
+		t.Fatalf("EditPage failed after retry: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success after badtoken retry")
+	}
+	if attempts != 2 {
+		t.Errorf("Expected 2 edit attempts, got %d", attempts)
+	}
+}
+
 func TestFindReplace_Success(t *testing.T) {
 	callCount := 0
 	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Adds `invalidateCSRFToken()` to clear cached tokens when MediaWiki rejects them
- EditPage, UploadFile, and MovePage now detect `badtoken` errors, invalidate the cache, and retry once with a fresh token
- Tests for token invalidation and the retry path

Fixes #34

## Test plan

- [x] `TestInvalidateCSRFToken` verifies token cache is cleared
- [x] `TestEditPage_BadTokenRetry` verifies retry succeeds after badtoken
- [x] Full test suite passes with `-race`
- [x] Zero lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)