### PR TITLE
ci: auto-dispatch mcp-registry.yml from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build:
@@ -89,3 +90,16 @@ jobs:
           draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger MCP Registry publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GITHUB_TOKEN-created releases don't fire release:published events
+          # (GitHub anti-recursion). Dispatch mcp-registry.yml explicitly.
+          # Strip leading 'v' from tag since mcp-registry.yml expects bare semver.
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Dispatching mcp-registry.yml for ${GITHUB_REF_NAME} (version=${VERSION})"
+          gh workflow run mcp-registry.yml \
+            --ref "${GITHUB_REF_NAME}" \
+            -f version="${VERSION}"


### PR DESCRIPTION
## Summary

GITHUB_TOKEN-created releases don't fire release:published events (anti-recursion). That means `mcp-registry.yml` never fires automatically after a release; every release needs a manual `gh workflow run` to publish to the MCP Registry. Hit this shipping v1.29.0 on 24-04-2026.

## Fix

Add a final step to the release job that dispatches `mcp-registry.yml` with the correct version format (strips the `v` prefix because `mcp-registry.yml` release-path does `${VERSION#v}` but workflow_dispatch takes input verbatim). Bumps permissions to include `actions: write`.

## Verification

- YAML validates locally
- Actual exercise only at next release; pre-existing risk for release workflow changes

## Companion fixes

Same pattern applies to miro-mcp-server and productplan-mcp-server. Separate PRs.

Fixes bead `claude-code-config-xxr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)