### PR TITLE
security: implement validateFileURL referenced by lying nosec comment

### DIFF
--- a/wiki/client.go
+++ b/wiki/client.go
@@ -69,6 +69,11 @@ type Client struct {
 
 	// Audit logging for write operations
 	auditLogger AuditLogger
+
+	// allowPrivateDownloadForTest, when true, bypasses validateFileURL in
+	// downloadFile so httptest servers (bound to 127.0.0.1) work. Production
+	// code never sets this; it is only flipped on by tests in this package.
+	allowPrivateDownloadForTest bool
 }
 
 // MaxConcurrentRequests limits parallel API calls to prevent overwhelming the server

--- a/wiki/security.go
+++ b/wiki/security.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"syscall"
 	"time"
 )
@@ -114,6 +115,110 @@ func isPrivateIP(ip net.IP) bool {
 		}
 	}
 	return false
+}
+
+// downloadClient is a shared HTTP client for file downloads with SSRF protections.
+// Mirrors linkCheckClient: safeDialer for DNS-rebinding protection plus a
+// CheckRedirect that re-validates redirect targets so a public host can't
+// 302 the download path into a private network (e.g. cloud metadata).
+var downloadClient = &http.Client{
+	Timeout: 60 * time.Second,
+	Transport: &http.Transport{
+		DialContext:         safeDialer.DialContext,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+		ForceAttemptHTTP2:   true,
+	},
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		// Allow up to 5 redirects (matches linkCheckClient).
+		if len(via) >= 5 {
+			return fmt.Errorf("too many redirects")
+		}
+
+		// Re-validate the redirect target. Without this, a public-IP server
+		// could return 302 Location: http://169.254.169.254/ and the Go
+		// http.Client would happily follow it.
+		if hostname := req.URL.Hostname(); hostname != "" {
+			isPrivate, _ := isPrivateHost(hostname)
+			if isPrivate {
+				return &SSRFError{
+					Code:    SSRFCodeRedirect,
+					URL:     req.URL.String(),
+					Reason:  "redirect to private network blocked",
+					Blocked: true,
+				}
+			}
+		}
+
+		return nil
+	},
+}
+
+// validateFileURL checks whether a download URL is safe to fetch.
+// Used by Client.downloadFile to enforce SSRF protections at the call site,
+// in addition to the safeDialer / CheckRedirect guards on downloadClient
+// (defense in depth: the dialer protects against DNS rebinding, this catches
+// obviously bad URLs early with a structured SSRFError).
+//
+// Allowed: http(s) URLs whose host (or all DNS-resolved IPs) are public.
+// Blocked: private/internal IPs, link-local, loopback, multicast, malformed
+// URLs, non-http(s) schemes, and DNS-resolution failures (fail-closed).
+func validateFileURL(rawURL string) error {
+	if rawURL == "" {
+		return &SSRFError{
+			Code:    SSRFCodeInvalidURL,
+			URL:     rawURL,
+			Reason:  "empty URL",
+			Blocked: true,
+		}
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return &SSRFError{
+			Code:    SSRFCodeInvalidURL,
+			URL:     rawURL,
+			Reason:  fmt.Sprintf("URL parse failed: %v", err),
+			Blocked: true,
+		}
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return &SSRFError{
+			Code:    SSRFCodeInvalidURL,
+			URL:     rawURL,
+			Reason:  fmt.Sprintf("unsupported scheme %q (only http/https allowed)", parsed.Scheme),
+			Blocked: true,
+		}
+	}
+
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return &SSRFError{
+			Code:    SSRFCodeInvalidURL,
+			URL:     rawURL,
+			Reason:  "missing host",
+			Blocked: true,
+		}
+	}
+
+	isPrivate, ssrfErr := isPrivateHost(hostname)
+	if isPrivate {
+		if ssrfErr != nil {
+			// DNS error - return the structured error (fail-closed)
+			return ssrfErr
+		}
+		return &SSRFError{
+			Code:    SSRFCodePrivateIP,
+			URL:     rawURL,
+			Reason:  fmt.Sprintf("host %q resolves to a private/internal network", hostname),
+			Blocked: true,
+		}
+	}
+
+	return nil
 }
 
 // isPrivateHost checks if a hostname resolves to any private IP

--- a/wiki/security_test.go
+++ b/wiki/security_test.go
@@ -1,6 +1,9 @@
 package wiki
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -612,5 +615,186 @@ func TestSecurity_UnicodeBypassPrevention(t *testing.T) {
 				t.Errorf("Expected content to be allowed: %q, got error: %v", tc.content, err)
 			}
 		})
+	}
+}
+
+// TestValidateFileURL_PrivateIPs covers the SSRF guard on downloadFile's
+// validateFileURL helper. These are the URLs a malicious wiki imageinfo
+// response (or any future user-supplied caller) could try to reach.
+func TestValidateFileURL_PrivateIPs(t *testing.T) {
+	blockedURLs := []struct {
+		url  string
+		desc string
+	}{
+		{"http://169.254.169.254/latest/meta-data/", "AWS metadata endpoint"},
+		{"http://169.254.169.254/computeMetadata/v1/", "GCP metadata endpoint"},
+		{"http://10.0.0.1/internal", "RFC1918 class A"},
+		{"http://192.168.1.1/router", "RFC1918 class C"},
+		{"http://172.16.0.1/internal", "RFC1918 class B"},
+		{"http://127.0.0.1/local", "loopback IPv4"},
+		{"http://[::1]/local", "loopback IPv6"},
+		{"http://localhost/", "loopback by name"},
+		{"http://0.0.0.0/", "current network"},
+		{"http://100.64.0.1/", "shared address space (CGN)"},
+	}
+
+	for _, tc := range blockedURLs {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validateFileURL(tc.url)
+			if err == nil {
+				t.Fatalf("Expected validateFileURL(%q) to fail, but it succeeded", tc.url)
+			}
+			ssrfErr, ok := err.(*SSRFError)
+			if !ok {
+				t.Fatalf("Expected *SSRFError, got %T: %v", err, err)
+			}
+			if ssrfErr.Code != SSRFCodePrivateIP {
+				t.Errorf("Expected code %s, got %s", SSRFCodePrivateIP, ssrfErr.Code)
+			}
+		})
+	}
+}
+
+func TestValidateFileURL_InvalidURLs(t *testing.T) {
+	invalidURLs := []struct {
+		url  string
+		desc string
+	}{
+		{"", "empty"},
+		{"file:///etc/passwd", "file scheme"},
+		{"ftp://example.com/", "ftp scheme"},
+		{"gopher://example.com/", "gopher scheme"},
+		{"javascript:alert(1)", "javascript scheme"},
+		{"http://", "missing host"},
+		{"://example.com", "missing scheme"},
+	}
+
+	for _, tc := range invalidURLs {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validateFileURL(tc.url)
+			if err == nil {
+				t.Fatalf("Expected validateFileURL(%q) to fail, but it succeeded", tc.url)
+			}
+			ssrfErr, ok := err.(*SSRFError)
+			if !ok {
+				t.Fatalf("Expected *SSRFError, got %T: %v", err, err)
+			}
+			if ssrfErr.Code != SSRFCodeInvalidURL {
+				t.Errorf("Expected code %s, got %s", SSRFCodeInvalidURL, ssrfErr.Code)
+			}
+		})
+	}
+}
+
+// TestValidateFileURL_DNSFailureFailsClosed ensures a hostname that doesn't
+// resolve is blocked rather than allowed (matches the policy of isPrivateHost
+// elsewhere in security.go).
+func TestValidateFileURL_DNSFailureFailsClosed(t *testing.T) {
+	err := validateFileURL("http://this-domain-definitely-does-not-exist-12345.invalid/file.pdf")
+	if err == nil {
+		t.Fatal("Expected DNS failure to fail closed (block), got nil")
+	}
+	ssrfErr, ok := err.(*SSRFError)
+	if !ok {
+		t.Fatalf("Expected *SSRFError, got %T: %v", err, err)
+	}
+	if ssrfErr.Code != SSRFCodeDNSError {
+		t.Errorf("Expected code %s, got %s", SSRFCodeDNSError, ssrfErr.Code)
+	}
+}
+
+// TestDownloadFile_BlocksPrivateIP confirms the lying-#nosec gap is closed:
+// downloadFile now refuses to fetch private/internal URLs even though the
+// underlying httpClient could reach them.
+func TestDownloadFile_BlocksPrivateIP(t *testing.T) {
+	// Use an httptest server only as a baseline Client; we never call it.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+	// NOTE: deliberately not setting allowPrivateDownloadForTest. We want
+	// the production validation path here.
+
+	ctx := context.Background()
+	blocked := []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://10.0.0.1/internal",
+		"http://127.0.0.1/local",
+	}
+	for _, u := range blocked {
+		t.Run(u, func(t *testing.T) {
+			_, err := client.downloadFile(ctx, u)
+			if err == nil {
+				t.Fatalf("Expected downloadFile(%q) to be blocked, got nil", u)
+			}
+			if !strings.Contains(err.Error(), "download URL rejected") {
+				t.Errorf("Expected 'download URL rejected' in error, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestDownloadFile_RedirectToPrivateNetworkBlocked covers the SSRF-via-redirect
+// bypass: a public-IP server (or in this test, a localhost server we route
+// through with the test bypass) returning 302 Location: http://169.254.169.254/
+// must NOT cause downloadClient to follow into the private network.
+//
+// We exercise this by directly calling downloadClient.Do() against a server
+// that returns the malicious redirect. The CheckRedirect hook should reject
+// the second hop and the client should never reach the metadata endpoint.
+func TestDownloadFile_RedirectToPrivateNetworkBlocked(t *testing.T) {
+	metadataReached := false
+	// "metadata" server stand-in. If CheckRedirect is wired correctly, this
+	// handler should never be invoked.
+	metadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		metadataReached = true
+		_, _ = w.Write([]byte("LEAKED METADATA"))
+	}))
+	defer metadataServer.Close()
+
+	// "Public" server that 302s to the metadata endpoint.
+	redirectingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Build a redirect target that resolves to a private IP. Since
+		// httptest binds to 127.0.0.1, the redirect target IS a private
+		// IP, which is exactly the condition CheckRedirect must catch.
+		http.Redirect(w, nil, metadataServer.URL+"/leak", http.StatusFound)
+	}))
+	defer redirectingServer.Close()
+
+	// Drive downloadClient directly so we exercise CheckRedirect even though
+	// the public-IP simulation here also lives on loopback.
+	req, err := http.NewRequest("GET", redirectingServer.URL+"/start", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := downloadClient.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("Expected redirect to be blocked, got nil error")
+	}
+	if metadataReached {
+		t.Fatal("FAIL: redirect followed into 'metadata' endpoint - SSRF bypass")
+	}
+}
+
+// TestDownloadFile_PublicURLRegression keeps the happy path covered: a
+// well-formed public-looking URL that fails validation only because of DNS
+// (the test never goes to the network for a real public host) should report
+// the validation failure cleanly, while a routed test server with the bypass
+// flag works end-to-end. The end-to-end bypass case is already covered by
+// TestDownloadFile_Success; here we just sanity-check that validateFileURL
+// accepts a syntactically valid public URL form on the parse + scheme path.
+func TestValidateFileURL_AcceptsPublicForm(t *testing.T) {
+	// 8.8.8.8 is Google DNS - public, will resolve, will not block.
+	if err := validateFileURL("http://8.8.8.8/file.txt"); err != nil {
+		t.Errorf("Expected public IP URL to pass validation, got: %v", err)
+	}
+	if err := validateFileURL("https://1.1.1.1/file.txt"); err != nil {
+		t.Errorf("Expected public IP URL to pass validation, got: %v", err)
 	}
 }

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -844,8 +844,29 @@ func (c *Client) getFileURL(ctx context.Context, filename string) (string, strin
 	return "", "", fmt.Errorf("file '%s' not found", filename)
 }
 
-// downloadFile downloads a file from the given URL
+// downloadFile downloads a file from the given URL.
+//
+// SECURITY: The fileURL is validated against SSRF (private IPs, DNS rebinding,
+// redirect bypass) via validateFileURL before any network I/O. The actual
+// HTTP request goes through downloadClient, which uses safeDialer +
+// CheckRedirect for defense in depth. Callers in production today (only
+// SearchInFile) get fileURL from the wiki's own imageinfo API, so the URL is
+// already trusted. The validation closes the gap for any future caller that
+// might accept user-supplied URLs.
+//
+// Tests can set c.allowPrivateDownloadForTest to skip validation against
+// httptest servers (which bind to 127.0.0.1).
 func (c *Client) downloadFile(ctx context.Context, fileURL string) ([]byte, error) {
+	httpClient := downloadClient
+	if !c.allowPrivateDownloadForTest {
+		if err := validateFileURL(fileURL); err != nil {
+			return nil, fmt.Errorf("download URL rejected: %w", err)
+		}
+	} else {
+		// Test path: bypass SSRF guards so httptest (loopback) servers work.
+		httpClient = c.httpClient
+	}
+
 	req, err := http.NewRequestWithContext(ctx, "GET", fileURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -853,7 +874,7 @@ func (c *Client) downloadFile(ctx context.Context, fileURL string) ([]byte, erro
 
 	req.Header.Set("User-Agent", c.config.UserAgent)
 
-	resp, err := c.httpClient.Do(req) // #nosec G704 -- fileURL validated by validateFileURL in security.go before reaching here
+	resp, err := httpClient.Do(req) // #nosec G107 G704 -- URL validated by validateFileURL; request goes through downloadClient (safeDialer + CheckRedirect)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download: %w", err)
 	}

--- a/wiki/write_test.go
+++ b/wiki/write_test.go
@@ -1228,6 +1228,8 @@ func TestDownloadFile_Success(t *testing.T) {
 
 	client := createMockClient(t, fileServer)
 	defer client.Close()
+	// httptest binds to 127.0.0.1, which validateFileURL would block.
+	client.allowPrivateDownloadForTest = true
 
 	ctx := context.Background()
 	content, err := client.downloadFile(ctx, fileServer.URL+"/test.txt")
@@ -1248,6 +1250,7 @@ func TestDownloadFile_NotFound(t *testing.T) {
 
 	client := createMockClient(t, fileServer)
 	defer client.Close()
+	client.allowPrivateDownloadForTest = true
 
 	ctx := context.Background()
 	_, err := client.downloadFile(ctx, fileServer.URL+"/notfound.txt")


### PR DESCRIPTION
## Summary
- Implements `validateFileURL` in `wiki/security.go` referenced by a **lying `#nosec` comment** at `wiki/write.go:856` ("validated by validateFileURL in security.go before reaching here" — no such function existed in the codebase)
- `downloadFile` now pre-validates the URL and routes through a guarded `downloadClient` (safeDialer transport + CheckRedirect re-validating on each hop), mirroring the pattern of the existing `linkCheckClient`
- **Real-world risk was low today** (`SearchInFile` is the only caller; URLs come from the wiki's own `imageinfo` API), but the lying comment would have misled future reviewers and the gap would have become exploitable at the first user-supplied URL caller
- Audit trail: `claude-code-config-dx2` verification follow-up

## Test plan
- [x] `go test ./... -race -failfast` all packages pass
- [x] `golangci-lint run ./...` zero issues
- [x] `gosec ./wiki/...` zero issues
- [x] New tests in `wiki/security_test.go`:
  - `TestValidateFileURL_PrivateIPs` (10 subtests: AWS metadata `169.254.169.254`, GCP metadata, RFC1918 A/B/C, loopback v4/v6, localhost-by-name, `0.0.0.0`, CGN)
  - `TestValidateFileURL_InvalidURLs` (empty, `file://`, `ftp://`, `gopher://`, `javascript:`, missing host/scheme)
  - `TestValidateFileURL_DNSFailureFailsClosed` (unresolvable host → `SSRFCodeDNSError`)
  - `TestValidateFileURL_AcceptsPublicForm` (8.8.8.8, 1.1.1.1 pass)
  - `TestDownloadFile_BlocksPrivateIP` (end-to-end through `downloadFile`)
  - `TestDownloadFile_RedirectToPrivateNetworkBlocked` (302-to-private bypass scenario; asserts metadata handler never invoked)

## Why Option A (validateFileURL in security.go), not Option B (separate download client)
`wiki/security.go` already had a clean SSRF pattern — `safeDialer` + `linkCheckClient` + `CheckRedirect`. The lying comment literally referenced the validateFileURL name. Mirroring the existing pattern (rather than inventing a download-only mechanism) keeps SSRF protection consistent between link checking and file download.

## Truthful comment replacement
Replaces the lying `#nosec G704` with `#nosec G107 G704 -- URL validated by validateFileURL; request goes through downloadClient (safeDialer + CheckRedirect)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)