### PR TITLE
fix(ci): remove release: published trigger from mcp-registry.yml

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,8 +1,13 @@
 name: Publish to MCP Registry
 
+# Triggered exclusively by release.yml's "Trigger MCP Registry publish" step
+# (gh workflow run mcp-registry.yml -f version=...). The release: published
+# event is intentionally NOT a trigger here — it would double-fire alongside
+# the explicit dispatch (observed in productplan-mcp-server v5.0.1 on
+# 26-04-2026: first run published, second run failed with
+# "cannot publish duplicate version"). Same pattern existed here; preempted.
+# workflow_dispatch also covers manual reruns when a registry publish fails.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -25,12 +30,7 @@ jobs:
       - name: Get version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
-          else
-            VERSION="${{ github.event.inputs.version }}"
-          fi
+          VERSION="${{ github.event.inputs.version }}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Wait for Docker image


### PR DESCRIPTION
## Summary

Port of [productplan-mcp-server PR #27](https://github.com/olgasafonova/productplan-mcp-server/pull/27). Same workflow shape, same time-bomb pattern, preempting before it fires.

`mcp-registry.yml` had two triggers:
1. `release: published` event
2. `workflow_dispatch` — invoked explicitly from `release.yml` after the GitHub release lands

Productplan v5.0.1 (26-04-2026) showed both fire for the same release:
- 14:58:17 UTC — `workflow_dispatch` from release.yml — **success**
- 14:58:53 UTC — `release: published` event — **failure** (`cannot publish duplicate version`)

This repo has the identical setup but hasn't released since the explicit dispatch was added, so the duplicate hasn't materialized here yet. Removing `release: published` makes release.yml's explicit dispatch the single canonical path. `workflow_dispatch` remains for manual reruns.

## Side cleanup

The "Get version" step previously branched on `github.event_name`. With only `workflow_dispatch` reaching the workflow, the branch is dead code. Simplified to a single line.

## Test plan

- [x] YAML syntax valid (rendered diff)
- [ ] Manual: cut a follow-up patch release after merge and verify only one registry-publish run appears, triggered by `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)