### PR TITLE
chore: add AGENTS.md (bd-onboard template)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --status in_progress  # Claim work
+bd close <id>         # Complete work
+bd sync               # Sync with git
+```
+
+## Landing the Plane (Session Completion)
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd sync
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+


### PR DESCRIPTION
## Summary
- Adopts the canonical AGENTS.md operational-rules file at repo root.
- Identical content to public360-mcp-server/AGENTS.md (bd workflow + session-completion discipline).
- Required by AGENTS.md convergence-default-status established 02-05-2026 (see `claude-code-config/memory/agents_md_canonical.md` 6th-occurrence section).

Closes `claude-code-config-a1s`. Companion to `claude-code-config-uq2` (gleif-mcp-server, already merged to main).

## Test plan
- [ ] AGENTS.md renders correctly in GitHub
- [ ] No CI failures (file-only change, no code paths affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)