### PR TITLE
security: close 307/308 credential leak, HG-2 raw body, HG-3 upload gaps

### DIFF
--- a/tools/definitions.go
+++ b/tools/definitions.go
@@ -912,7 +912,7 @@ PARAMETERS:
 
 RETURNS: Which categories were added, removed, already present, or not found. Includes revision ID, diff URL, and undo instructions.`,
 		ReadOnly:    false,
-		Destructive: false,
+		Destructive: true, // HG-3: edits page content (changes category set via EditPage)
 		Idempotent:  false,
 		OpenWorld:   true,
 	},
@@ -962,9 +962,11 @@ PARAMETERS:
 
 RETURNS: Upload status and file page URL. Includes revision ID, diff URL, and undo instructions.
 
-NOTE: Requires authentication. URL must be publicly accessible.`,
+NOTE: Requires authentication. URL must be publicly accessible.
+
+SECURITY: Source URL must be on the MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS env-var allowlist (fail-closed when unset). Private/internal IPs are blocked unconditionally. ignore_warnings=true overwrites existing files; the destructive-hint annotation is set so hosts that gate destructive operations will prompt before this runs.`,
 		ReadOnly:    false,
-		Destructive: false,
+		Destructive: true, // HG-3: writes attacker-controllable bytes to the wiki and (with ignore_warnings) overwrites existing files
 		Idempotent:  false,
 		OpenWorld:   true,
 	},

--- a/wiki/client.go
+++ b/wiki/client.go
@@ -553,7 +553,16 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 
 			// Don't retry client errors (4xx) except rate limiting (429)
 			if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 {
-				return nil, fmt.Errorf("client error %d: %s", resp.StatusCode, string(body))
+				// SECURITY (HG-2): never echo the raw response body to the
+				// MCP caller. The body may contain HTML error pages, MITM
+				// proxy responses, or echoed login form parameters. Log the
+				// truncated body for server-side diagnostics; surface only
+				// the structured error to the caller.
+				apiErr := NewAPIError(resp.StatusCode, body)
+				c.logger.Warn("API client error response",
+					"status", resp.StatusCode,
+					"body_snippet", apiErr.BodySnippet)
+				return nil, apiErr
 			}
 
 			// Handle rate limiting with Retry-After header
@@ -573,10 +582,15 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 				}
 			}
 
-			lastErr = fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+			// SECURITY (HG-2): structured error retains status + correlation
+			// without echoing the raw body. Body snippet captured for server-
+			// side logging only; never reaches the MCP caller.
+			apiErr := NewAPIError(resp.StatusCode, body)
+			lastErr = apiErr
 			c.logger.Warn("API returned non-OK status",
 				"status", resp.StatusCode,
-				"attempt", attempt+1)
+				"attempt", attempt+1,
+				"body_snippet", apiErr.BodySnippet)
 			continue
 		}
 

--- a/wiki/client.go
+++ b/wiki/client.go
@@ -122,6 +122,16 @@ func NewClient(config *Config, logger *slog.Logger) *Client {
 			Timeout:   config.Timeout,
 			Jar:       jar,
 			Transport: transport,
+			// SECURITY: Refuse all redirects on the API client. The client carries
+			// bot credentials and CSRF tokens; an HTTP 307/308 redirect would cause
+			// Go's default policy to re-POST the body (including lgpassword) to the
+			// new origin. The configured wiki URL is the only legitimate target,
+			// so any redirect indicates either misconfiguration or a credential-
+			// exfiltration attempt. Returning http.ErrUseLastResponse short-circuits
+			// the redirect and lets the caller handle the 3xx response itself.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		},
 		logger:         logger,
 		semaphore:      sem,
@@ -532,6 +542,15 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 
 		// Handle different status codes appropriately
 		if resp.StatusCode != http.StatusOK {
+			// SECURITY: 3xx responses indicate the wiki tried to redirect the
+			// authenticated request. CheckRedirect returns ErrUseLastResponse
+			// which surfaces the 3xx body here. Refuse to retry or follow;
+			// surface a clear configuration/integrity error to the caller.
+			if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+				location := resp.Header.Get("Location")
+				return nil, fmt.Errorf("wiki returned redirect %d (refused; API client does not follow redirects): Location=%q", resp.StatusCode, location)
+			}
+
 			// Don't retry client errors (4xx) except rate limiting (429)
 			if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 {
 				return nil, fmt.Errorf("client error %d: %s", resp.StatusCode, string(body))

--- a/wiki/client_apierror_test.go
+++ b/wiki/client_apierror_test.go
@@ -1,0 +1,153 @@
+package wiki
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAPIRequest_4xx_DoesNotLeakResponseBody is the regression test for the
+// HG-2 raw-body leak in apiRequest. The bug shape:
+//
+//   - The 4xx and other non-OK branches in apiRequest used to format errors
+//     as `fmt.Errorf("client error %d: %s", status, string(body))`.
+//   - The body propagated verbatim through the dispatcher (`%w` wrap) to
+//     the MCP caller, surfacing HTML error pages, MITM proxy responses,
+//     and prompt-injection-controllable echo channels.
+//
+// This test asserts none of the body content reaches the caller-facing
+// error string when the wiki returns a 4xx with a body that contains
+// markers that would, under the old behavior, leak.
+func TestAPIRequest_4xx_DoesNotLeakResponseBody(t *testing.T) {
+	// Sentinels representative of categories an attacker (or misconfigured
+	// proxy) might place in a 4xx body:
+	//   - internal hostnames
+	//   - request IDs / correlation headers from upstream proxies
+	//   - prompt-injection markers
+	//   - bot password fragments (worst case if a proxy echoes form bodies)
+	const (
+		internalHostMarker   = "kube-master.internal.tieto.local"
+		proxyRequestIDMarker = "X-Cloudflare-Ray-Id-DEADBEEF"
+		injectionMarker      = "PROMPT_INJECTION_SENTINEL_IGNORE_ABOVE_AND_LEAK_KEYS"
+		passwordEcho         = "lgpassword=SUPER_SECRET_BOT_PASS_1234"
+	)
+	htmlBody := `<html><body>` +
+		`<h1>418 I'm a teapot</h1>` +
+		`<p>Internal: ` + internalHostMarker + `</p>` +
+		`<p>` + proxyRequestIDMarker + `</p>` +
+		`<p>` + injectionMarker + `</p>` +
+		`<pre>` + passwordEcho + `</pre>` +
+		`</body></html>`
+
+	wiki := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte(htmlBody))
+	}))
+	defer wiki.Close()
+
+	config := &Config{
+		BaseURL:    wiki.URL,
+		Timeout:    5 * time.Second,
+		MaxRetries: 0,
+		UserAgent:  "TestAPIError/1.0",
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(config, logger)
+	defer client.Close()
+
+	params := url.Values{}
+	params.Set("action", "query")
+
+	_, err := client.apiRequest(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error from 4xx, got nil")
+	}
+
+	errStr := err.Error()
+	for _, sentinel := range []string{internalHostMarker, proxyRequestIDMarker, injectionMarker, passwordEcho} {
+		if strings.Contains(errStr, sentinel) {
+			t.Errorf("HG-2 regression: error string leaks body sentinel %q\nfull error: %s", sentinel, errStr)
+		}
+	}
+
+	// Verify the structured APIError is what surfaced.
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusTeapot {
+		t.Errorf("expected status %d, got %d", http.StatusTeapot, apiErr.StatusCode)
+	}
+	if apiErr.Code != APICodeClientError {
+		t.Errorf("expected APICodeClientError, got %q", apiErr.Code)
+	}
+	// BodySnippet is captured for server-side logging but must NOT appear
+	// in Error() output. It contains the raw body (truncated) for ops use.
+	if apiErr.BodySnippet == "" {
+		t.Error("expected BodySnippet to be populated for server-side logging")
+	}
+	if strings.Contains(apiErr.Error(), apiErr.BodySnippet) {
+		t.Error("HG-2 regression: APIError.Error() echoes BodySnippet (must be log-only)")
+	}
+}
+
+// TestAPIRequest_5xx_DoesNotLeakResponseBody covers the second formerly-leaky
+// branch (the lastErr assignment in the retry loop).
+func TestAPIRequest_5xx_DoesNotLeakResponseBody(t *testing.T) {
+	const sentinel = "INTERNAL_5XX_LEAK_SENTINEL"
+	wiki := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Internal error: " + sentinel + " stack trace ..."))
+	}))
+	defer wiki.Close()
+
+	config := &Config{
+		BaseURL:    wiki.URL,
+		Timeout:    5 * time.Second,
+		MaxRetries: 1, // One retry so we exercise the lastErr path
+		UserAgent:  "TestAPIError/1.0",
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(config, logger)
+	defer client.Close()
+
+	params := url.Values{}
+	params.Set("action", "query")
+
+	_, err := client.apiRequest(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error from 5xx, got nil")
+	}
+	if strings.Contains(err.Error(), sentinel) {
+		t.Errorf("HG-2 regression: 5xx error string leaks body sentinel\nfull error: %s", err.Error())
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.Code != APICodeServerError {
+		t.Errorf("expected APICodeServerError, got %q", apiErr.Code)
+	}
+}
+
+// TestAPIError_BodySnippetTruncation ensures very long bodies are capped.
+func TestAPIError_BodySnippetTruncation(t *testing.T) {
+	body := strings.Repeat("X", APIErrorBodyMax*4)
+	apiErr := NewAPIError(http.StatusBadRequest, []byte(body))
+
+	if len(apiErr.BodySnippet) != APIErrorBodyMax {
+		t.Errorf("expected BodySnippet length %d, got %d", APIErrorBodyMax, len(apiErr.BodySnippet))
+	}
+	if strings.Contains(apiErr.Error(), apiErr.BodySnippet) {
+		t.Error("HG-2 regression: long body leaks via Error()")
+	}
+}

--- a/wiki/client_redirect_test.go
+++ b/wiki/client_redirect_test.go
@@ -1,0 +1,174 @@
+package wiki
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestAPIClientRefusesCrossOriginRedirect_307 is the regression test for the
+// 307/308 cross-origin credential-leak vulnerability. The bug shape:
+//
+//   - Client.httpClient is constructed with no CheckRedirect policy.
+//   - Go's default policy follows up to 10 redirects.
+//   - For HTTP 307/308 specifically, the original method AND request body
+//     are preserved across origins.
+//   - The login flow at client.go's loginFresh POSTs an action=login form
+//     containing lgpassword=<bot-password> via apiRequest.
+//   - A wiki that returns 307 Location: https://attacker/... causes Go to
+//     re-POST the entire form (including the password) to the attacker.
+//
+// This test verifies the fix: the client must refuse all redirects on the
+// API client (CheckRedirect returns http.ErrUseLastResponse) so the 3xx
+// response surfaces to the caller as an error without re-POSTing.
+func TestAPIClientRefusesCrossOriginRedirect_307(t *testing.T) {
+	// "Attacker" server: counts requests received and records bodies.
+	var attackerHits int32
+	var attackerBody string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attackerHits, 1)
+		body, _ := io.ReadAll(r.Body)
+		attackerBody = string(body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"login":{"result":"Success"}}`))
+	}))
+	defer attacker.Close()
+
+	// "Wiki" server: returns 307 with Location pointing to the attacker.
+	wiki := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", attacker.URL+"/exfil")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer wiki.Close()
+
+	config := &Config{
+		BaseURL:    wiki.URL,
+		Timeout:    5 * time.Second,
+		MaxRetries: 0,
+		UserAgent:  "TestRedirect/1.0",
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(config, logger)
+	defer client.Close()
+
+	// Sensitive payload: an attacker-controllable redirect on the login leg
+	// would re-POST this body (including lgpassword) to the attacker URL.
+	const sentinelPassword = "SECRET_BOT_PASSWORD_DO_NOT_LEAK"
+	params := url.Values{}
+	params.Set("action", "login")
+	params.Set("lgname", "TestBot@MCPLogin")
+	params.Set("lgpassword", sentinelPassword)
+	params.Set("lgtoken", "TOKEN")
+
+	_, err := client.apiRequest(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error from refused redirect, got nil")
+	}
+
+	// The attacker must NOT have received the body.
+	if hits := atomic.LoadInt32(&attackerHits); hits != 0 {
+		t.Errorf("attacker received %d requests; expected 0 (redirect must be refused)", hits)
+	}
+	if strings.Contains(attackerBody, sentinelPassword) {
+		t.Errorf("attacker captured the bot password — credential leak via 307 redirect")
+	}
+
+	// The error must mention the redirect status and Location for diagnosability,
+	// but must NOT echo the lgpassword (the body is not in the redirect response;
+	// this is belt-and-braces against future regressions).
+	if !strings.Contains(err.Error(), "redirect 307") {
+		t.Errorf("error should mention refused redirect status; got: %v", err)
+	}
+	if strings.Contains(err.Error(), sentinelPassword) {
+		t.Errorf("error message leaked the bot password: %v", err)
+	}
+}
+
+// TestAPIClientRefusesCrossOriginRedirect_308 covers HTTP 308 Permanent
+// Redirect, which has the same body-preservation semantics as 307.
+func TestAPIClientRefusesCrossOriginRedirect_308(t *testing.T) {
+	var attackerHits int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attackerHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	wiki := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", attacker.URL)
+		w.WriteHeader(http.StatusPermanentRedirect)
+	}))
+	defer wiki.Close()
+
+	config := &Config{
+		BaseURL:    wiki.URL,
+		Timeout:    5 * time.Second,
+		MaxRetries: 0,
+		UserAgent:  "TestRedirect/1.0",
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(config, logger)
+	defer client.Close()
+
+	params := url.Values{}
+	params.Set("action", "query")
+
+	_, err := client.apiRequest(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error from refused redirect, got nil")
+	}
+	if hits := atomic.LoadInt32(&attackerHits); hits != 0 {
+		t.Errorf("attacker received %d requests; expected 0", hits)
+	}
+	if !strings.Contains(err.Error(), "redirect 308") {
+		t.Errorf("error should mention refused 308 redirect; got: %v", err)
+	}
+}
+
+// TestAPIClientRefusesSchemeDowngrade302 covers a weaker but still relevant
+// case: 302 Found doesn't preserve POST body in browsers, but Go's default
+// policy historically did for 301/302/303 in some cases. The fix is the same:
+// refuse all redirects on the API client.
+func TestAPIClientRefusesSchemeDowngrade302(t *testing.T) {
+	var attackerHits int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attackerHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	wiki := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", attacker.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer wiki.Close()
+
+	config := &Config{
+		BaseURL:    wiki.URL,
+		Timeout:    5 * time.Second,
+		MaxRetries: 0,
+		UserAgent:  "TestRedirect/1.0",
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewClient(config, logger)
+	defer client.Close()
+
+	params := url.Values{}
+	params.Set("action", "query")
+
+	_, err := client.apiRequest(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error from refused redirect, got nil")
+	}
+	if hits := atomic.LoadInt32(&attackerHits); hits != 0 {
+		t.Errorf("attacker received %d requests; expected 0", hits)
+	}
+}

--- a/wiki/errors.go
+++ b/wiki/errors.go
@@ -34,6 +34,11 @@ const (
 	// Not found error codes
 	NotFoundCodePage     ErrorCode = "NOT_FOUND_PAGE"
 	NotFoundCodeCategory ErrorCode = "NOT_FOUND_CATEGORY"
+
+	// API transport error codes (HTTP-level failures from the wiki API)
+	APICodeClientError ErrorCode = "API_CLIENT_ERROR" // 4xx (non-429)
+	APICodeServerError ErrorCode = "API_SERVER_ERROR" // 5xx
+	APICodeUnknown     ErrorCode = "API_UNKNOWN"      // 1xx, 2xx-non-200, anything else
 )
 
 // SSRFError represents a blocked SSRF attempt with structured error code
@@ -534,4 +539,65 @@ func WrapAPIError(code, info, operation string) *WikiError {
 	}
 
 	return err
+}
+
+// APIError represents a non-OK HTTP response from the wiki API.
+//
+// SECURITY (HG-2): the raw response body is never embedded in the error
+// message. The body may contain MediaWiki HTML error pages, MITM proxy
+// responses, or echoed POST parameters (worst-case lgpassword on the
+// login leg if a misconfigured proxy echoes request bodies). The Error()
+// method exposes only the HTTP status, code, and a stable status-text
+// message; the body is preserved on the struct via BodySnippet (capped
+// to APIErrorBodyMax bytes) for diagnostic logging by the SERVER, never
+// surfaced to MCP callers.
+type APIError struct {
+	StatusCode int
+	Code       ErrorCode
+	// BodySnippet is the truncated, server-only body capture for logging.
+	// It is NOT included in Error() output. Length capped at APIErrorBodyMax.
+	BodySnippet string
+}
+
+// APIErrorBodyMax caps the body snippet retained on APIError for server-side
+// logging. Beyond this we trade diagnostic depth for risk of leaking sensitive
+// state into log files (some operators ship logs to remote sinks).
+const APIErrorBodyMax = 256
+
+func (e *APIError) Error() string {
+	// Use http.StatusText via the standard library convention. We import
+	// net/http where APIError is constructed (in client.go) so the call
+	// site passes a stable description; here we just format what we have.
+	return fmt.Sprintf("wiki API error: HTTP %d (%s)", e.StatusCode, e.Code)
+}
+
+func (e *APIError) ErrorCode() ErrorCode {
+	return e.Code
+}
+
+// NewAPIError builds an APIError, classifying the status code into a stable
+// ErrorCode and capturing a truncated body snippet for server-side logging.
+// statusText should be the http.StatusText(statusCode) value; it is included
+// in the human-readable error message but the body is NOT.
+func NewAPIError(statusCode int, body []byte) *APIError {
+	var code ErrorCode
+	switch {
+	case statusCode >= 400 && statusCode < 500:
+		code = APICodeClientError
+	case statusCode >= 500 && statusCode < 600:
+		code = APICodeServerError
+	default:
+		code = APICodeUnknown
+	}
+
+	snippet := body
+	if len(snippet) > APIErrorBodyMax {
+		snippet = snippet[:APIErrorBodyMax]
+	}
+
+	return &APIError{
+		StatusCode:  statusCode,
+		Code:        code,
+		BodySnippet: string(snippet),
+	}
 }

--- a/wiki/security.go
+++ b/wiki/security.go
@@ -5,9 +5,93 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
 	"syscall"
 	"time"
 )
+
+// UploadAllowlistEnv names the env var that controls which source-URL hosts
+// mediawiki_upload_file may fetch from when uploading to the wiki via
+// uploadFromURL. Comma-separated list of hostnames; supports a leading
+// "*." for subdomain wildcards (e.g. "*.example.com" matches a.example.com
+// and b.c.example.com but NOT example.com itself).
+//
+// SECURITY (HG-3): unset or empty = deny-all (fail-closed). Mirrors the
+// MIRO_SHARE_ALLOWED_DOMAINS pattern documented in
+// rules/review-patterns.md.
+const UploadAllowlistEnv = "MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS"
+
+// validateUploadDomain enforces the source-URL host allowlist for the
+// mediawiki_upload_file tool's URL upload path. Returns nil if the host
+// is allowed, or a structured *SSRFError otherwise. Fail-closed when the
+// env var is unset.
+//
+// This pairs with validateFileURL (which blocks private-IP destinations)
+// to provide two independent gates: validateFileURL refuses internal
+// targets, validateUploadDomain refuses external targets that aren't on
+// the operator's positive list. The wiki upload-from-URL primitive grants
+// the wiki SSRF-on-behalf-of-the-bot access to any reachable URL, so
+// fail-closed is the correct default for an MCP-exposed tool.
+func validateUploadDomain(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return &SSRFError{
+			Code:    SSRFCodeInvalidURL,
+			URL:     rawURL,
+			Reason:  fmt.Sprintf("URL parse failed: %v", err),
+			Blocked: true,
+		}
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" {
+		return &SSRFError{
+			Code:    SSRFCodeInvalidURL,
+			URL:     rawURL,
+			Reason:  "missing host",
+			Blocked: true,
+		}
+	}
+
+	raw := strings.TrimSpace(os.Getenv(UploadAllowlistEnv))
+	if raw == "" {
+		return &SSRFError{
+			Code: SSRFCodePrivateIP,
+			URL:  rawURL,
+			Reason: fmt.Sprintf(
+				"upload source domain %q rejected: %s is unset or empty (fail-closed). "+
+					"Set %s=example.com,*.cdn.example.com to allow specific hosts.",
+				hostname, UploadAllowlistEnv, UploadAllowlistEnv),
+			Blocked: true,
+		}
+	}
+
+	for _, entry := range strings.Split(raw, ",") {
+		allowed := strings.TrimSpace(strings.ToLower(entry))
+		if allowed == "" {
+			continue
+		}
+		if strings.HasPrefix(allowed, "*.") {
+			suffix := allowed[1:] // ".example.com"
+			if strings.HasSuffix(hostname, suffix) && hostname != suffix[1:] {
+				return nil
+			}
+			continue
+		}
+		if hostname == allowed {
+			return nil
+		}
+	}
+
+	return &SSRFError{
+		Code: SSRFCodePrivateIP,
+		URL:  rawURL,
+		Reason: fmt.Sprintf(
+			"upload source domain %q is not on the %s allowlist",
+			hostname, UploadAllowlistEnv),
+		Blocked: true,
+	}
+}
 
 // Private/internal IP ranges that should be blocked for SSRF protection
 var (

--- a/wiki/upload_allowlist_test.go
+++ b/wiki/upload_allowlist_test.go
@@ -1,0 +1,108 @@
+package wiki
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestValidateUploadDomain_FailsClosedWhenEnvUnset asserts the HG-3 fail-closed
+// posture: with MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS unset, every URL is rejected.
+func TestValidateUploadDomain_FailsClosedWhenEnvUnset(t *testing.T) {
+	t.Setenv(UploadAllowlistEnv, "")
+
+	urls := []string{
+		"https://example.com/a.png",
+		"https://attacker.example/poison.svg",
+		"http://wiki.victim.tld/legit-looking.jpg",
+	}
+	for _, u := range urls {
+		err := validateUploadDomain(u)
+		if err == nil {
+			t.Errorf("HG-3 regression: %q allowed with empty allowlist (must fail-closed)", u)
+		}
+		var ssrf *SSRFError
+		if !errors.As(err, &ssrf) {
+			t.Errorf("expected *SSRFError for %q, got %T: %v", u, err, err)
+		}
+	}
+}
+
+func TestValidateUploadDomain_FailsClosedWhenEnvWhitespace(t *testing.T) {
+	t.Setenv(UploadAllowlistEnv, "   ,  ,   ")
+
+	if err := validateUploadDomain("https://example.com/a.png"); err == nil {
+		t.Error("HG-3 regression: whitespace-only allowlist treated as allow-all")
+	}
+}
+
+func TestValidateUploadDomain_AcceptsExactHost(t *testing.T) {
+	t.Setenv(UploadAllowlistEnv, "cdn.example.com,images.tieto.com")
+
+	if err := validateUploadDomain("https://cdn.example.com/foo.png"); err != nil {
+		t.Errorf("expected cdn.example.com to be allowed, got: %v", err)
+	}
+	if err := validateUploadDomain("https://images.tieto.com/bar.jpg"); err != nil {
+		t.Errorf("expected images.tieto.com to be allowed, got: %v", err)
+	}
+}
+
+func TestValidateUploadDomain_RejectsNonAllowlistedHost(t *testing.T) {
+	t.Setenv(UploadAllowlistEnv, "cdn.example.com")
+
+	err := validateUploadDomain("https://attacker.example/poison.svg")
+	if err == nil {
+		t.Fatal("expected attacker.example to be rejected")
+	}
+	if !strings.Contains(err.Error(), "attacker.example") {
+		t.Errorf("expected error to name the rejected host, got: %v", err)
+	}
+}
+
+func TestValidateUploadDomain_HandlesCase(t *testing.T) {
+	t.Setenv(UploadAllowlistEnv, "CDN.Example.Com")
+
+	if err := validateUploadDomain("https://cdn.example.com/foo.png"); err != nil {
+		t.Errorf("case-insensitive match failed: %v", err)
+	}
+	if err := validateUploadDomain("https://CDN.EXAMPLE.COM/foo.png"); err != nil {
+		t.Errorf("uppercase URL rejected: %v", err)
+	}
+}
+
+func TestValidateUploadDomain_WildcardSubdomain(t *testing.T) {
+	t.Setenv(UploadAllowlistEnv, "*.cdn.example.com")
+
+	// Should match a subdomain of cdn.example.com.
+	if err := validateUploadDomain("https://us.cdn.example.com/foo.png"); err != nil {
+		t.Errorf("wildcard subdomain rejected: %v", err)
+	}
+	if err := validateUploadDomain("https://eu.frankfurt.cdn.example.com/foo.png"); err != nil {
+		t.Errorf("nested wildcard subdomain rejected: %v", err)
+	}
+
+	// Wildcard "*.cdn.example.com" must NOT match cdn.example.com itself
+	// (this is the conservative reading; if the operator wants the apex
+	// they can list it separately). Critical because attacker may register
+	// cdn.example.com.evil.com style hostnames otherwise.
+	err := validateUploadDomain("https://cdn.example.com/foo.png")
+	if err == nil {
+		t.Error("wildcard pattern should not match its own apex")
+	}
+
+	// Must NOT match a different apex.
+	err = validateUploadDomain("https://cdn.example.com.evil.com/foo.png")
+	if err == nil {
+		t.Error("HG-3 regression: wildcard accepted a host whose suffix happens to match")
+	}
+}
+
+func TestValidateUploadDomain_MalformedURLRejected(t *testing.T) {
+	t.Setenv(UploadAllowlistEnv, "example.com")
+
+	for _, u := range []string{"://no-scheme", "http://", ""} {
+		if err := validateUploadDomain(u); err == nil {
+			t.Errorf("expected malformed URL %q to be rejected", u)
+		}
+	}
+}

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -615,8 +615,33 @@ func (c *Client) performUpload(ctx context.Context, args UploadFileArgs) (Upload
 	return c.uploadFromFile(ctx, args, token)
 }
 
-// uploadFromURL uploads a file from a URL
+// uploadFromURL uploads a file from a URL.
+//
+// SECURITY (HG-3): two independent gates protect the upload-from-URL path
+// from being used as a server-side request forgery primitive against the
+// wiki's network neighbors:
+//
+//  1. validateFileURL refuses URLs whose host (or any DNS-resolved IP)
+//     is private/internal — protects against wiki-as-SSRF-proxy targeting
+//     169.254.169.254 (cloud metadata), RFC1918 ranges, link-local, etc.
+//  2. validateUploadDomain refuses any host not present on the operator's
+//     positive allowlist (MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS). Fail-closed
+//     when unset — the wiki is the entity performing the fetch on the
+//     bot's behalf, and the agent caller is fully URL-controlling, so
+//     the operator must explicitly enumerate trusted source hosts.
+//
+// Without these gates, an adversarial MCP caller could pass
+// args.FileURL = "https://attacker.example/poisoned.svg" and have the
+// wiki fetch it (and on wikis that allow SVG, this becomes stored XSS
+// via the bot account when ignore_warnings overwrites an existing file).
 func (c *Client) uploadFromURL(ctx context.Context, args UploadFileArgs, token string) (UploadFileResult, error) {
+	if err := validateFileURL(args.FileURL); err != nil {
+		return UploadFileResult{}, err
+	}
+	if err := validateUploadDomain(args.FileURL); err != nil {
+		return UploadFileResult{}, err
+	}
+
 	params := url.Values{}
 	params.Set("action", "upload")
 	params.Set("filename", args.Filename)

--- a/wiki/write_test.go
+++ b/wiki/write_test.go
@@ -1349,6 +1349,11 @@ func TestUploadFile_FromURL_Success(t *testing.T) {
 	client.config.Password = "TestPass"
 	defer client.Close()
 
+	// HG-3: uploadFromURL now validates the source-URL host against
+	// MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS (fail-closed). Allow example.com
+	// for this success-path test.
+	t.Setenv(UploadAllowlistEnv, "example.com")
+
 	ctx := context.Background()
 	result, err := client.UploadFile(ctx, UploadFileArgs{
 		Filename:       "Test.png",


### PR DESCRIPTION
## Summary

Three security fixes for findings from the Carlini-style autonomous vulnerability scaffold sweep across the MCP portfolio. All three are on graduated hard gates from \`rules/review-patterns.md\`.

| # | Severity | File | Fix |
|---|---|---|---|
| 1 | **Critical** | \`wiki/client.go:121\` | API client refuses all redirects (closes 307/308 cross-origin credential leak) |
| 2 | High (HG-2) | \`wiki/client.go:556, :576\` | API errors no longer echo raw response body to MCP caller |
| 3 | Critical (HG-3) | \`tools/definitions.go\` + \`wiki/write.go\` + \`wiki/security.go\` | \`mediawiki_upload_file\` and \`manage_categories\` flipped to \`Destructive: true\`; \`uploadFromURL\` gains \`validateFileURL\` + new fail-closed \`MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS\` allowlist |

### 1. Critical: 307/308 cross-origin credential leak

The main \`Client.httpClient\` was constructed with no \`CheckRedirect\` policy. Go's default follows up to 10 redirects, and for HTTP 307 / 308 it preserves the original method AND request body across origins. The login flow POSTs \`lgpassword=<bot>\` via \`apiRequest\`. A wiki (or proxy in front of it, or MITM during DNS / TLS bootstrap) returning \`307 Location: https://attacker/\` causes Go to re-POST the entire form body — including \`lgpassword\` — to the attacker.

Fix: \`CheckRedirect\` returns \`http.ErrUseLastResponse\` for any redirect on the API client. The configured wiki URL is the only legitimate target; the MediaWiki API does not redirect under normal operation; refusing all redirects is the safest correct policy for a credential-bearing client. The status switch in \`apiRequest\` now explicitly handles 3xx responses (otherwise the retry loop wastes attempts).

Verified end-to-end with httptest. See commit \`b01cab1\`.

### 2. HG-2: raw-body leak in apiRequest error paths

Two call sites at \`wiki/client.go:537\` and \`:557\` formatted errors as \`fmt.Errorf("client error %d: %s", status, string(body))\`. The body propagated verbatim through \`%w\` wrapping at the dispatcher seam to the MCP caller. HTML error pages, MITM proxy responses, echoed login form parameters, all flowed through.

Fix: new \`APIError\` type in \`wiki/errors.go\` retains StatusCode + ErrorCode + a body snippet capped at 256 bytes for **server-side logging only**. \`Error()\` returns \`"wiki API error: HTTP %d (%s)"\` — never the body. Mirrors the gleif and miro reference implementations.

This is a regression of HG-2 graduated 2026-04-25. See commit \`7f8c2f6\`.

### 3. HG-3: \`mediawiki_upload_file\` misannotation + SSRF gap

Three sub-fixes in one commit:

- **Annotation flip:** \`mediawiki_upload_file\` (writes attacker-bytes to wiki, with \`ignore_warnings=true\` overwrites existing files — stored XSS via SVG on wikis that allow it) and \`mediawiki_manage_categories\` (edits page content) now declare \`Destructive: true\`. Hosts that gate destructive operations on the annotation will prompt before either tool runs.
- **SSRF gap closed:** \`uploadFromURL\` now calls \`validateFileURL\` (already correctly applied to the *download* path; the upload path was the asymmetric gap). Closes wiki-as-SSRF-proxy targeting cloud metadata endpoints.
- **Fail-closed allowlist:** new \`MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS\` env var. Mirrors the \`MIRO_SHARE_ALLOWED_DOMAINS\` pattern documented in \`rules/review-patterns.md\` (the HG-3 graduation reference). Comma-separated; supports leading \`*.\` wildcards (apex requires explicit listing); fail-closed when unset.

See commit \`5f7b9ba\`.

## Test plan

- [x] \`go test -race ./...\` — all packages green, 14s for wiki package.
- [x] \`golangci-lint run\` — 0 issues.
- [x] New tests:
  - \`wiki/client_redirect_test.go\` — 307, 308, 302 cross-origin attempts; assert attacker server receives **zero** requests, lgpassword sentinel does not reach attacker or appear in error string.
  - \`wiki/client_apierror_test.go\` — 4xx and 5xx with HTML body containing internal hostname / proxy request ID / prompt-injection sentinel / \`lgpassword=...\` echo; assert none reach the caller-facing error.
  - \`wiki/upload_allowlist_test.go\` — empty/whitespace env fail-closed, exact match, case insensitivity, wildcard subdomains (with apex separation and suffix-abuse protection).
- [x] Existing \`TestUploadFile_FromURL_Success\` updated with \`t.Setenv(UploadAllowlistEnv, "example.com")\` so the success path keeps passing under the new validators.

## UX impact

- **Operators using \`mediawiki_upload_file\`:** must now set \`MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS\` (e.g. \`MEDIAWIKI_UPLOAD_ALLOWED_DOMAINS=cdn.example.com,*.images.tieto.com\`). Without it the tool is unusable. This is the intended fail-closed posture.
- **Hosts gating on \`Destructive\`:** will now prompt before \`mediawiki_upload_file\` and \`mediawiki_manage_categories\` runs. This is a UX-positive correction; both tools were being silently passed through despite mutating wiki state.
- **API errors:** error messages no longer include the raw response body. Operators relying on body inspection in MCP error logs should switch to looking at the server's \`logger.Warn\` output, which now includes a truncated \`body_snippet\` field.

## Suggested release version

**v0.X.0** (minor) — fail-closed upload-domain allowlist is a behavior change. Two of the three fixes are HG-graduated regression patches.

## Out-of-scope follow-ups (will be beaded)

- **Audit logger fail-open** when \`MEDIAWIKI_AUDIT_LOG\` env unset (\`main.go:483-492\`). HIGH severity but not on a graduated hard gate; deserves its own focused PR.
- **Namespace XSS via write tools.** \`EditPage\`/\`FindReplace\`/\`ApplyFormatting\`/\`BulkReplace\`/\`ManageCategories\` can write to \`MediaWiki:Common.js\`, \`Module:*\`, \`User:*/common.js\`. Defense-in-depth: refuse writes to interface namespaces from MCP tools by default. HIGH severity, requires bot-account-rights threat-modeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)