### PR TITLE
fix(config): honor MEDIAWIKI_ALLOW_INSECURE env var

### DIFF
--- a/wiki/config.go
+++ b/wiki/config.go
@@ -60,8 +60,9 @@ Or in your MCP configuration:
 		}
 	}
 
-	// Validate URL format and enforce HTTPS
-	if err := validateWikiURL(baseURL); err != nil {
+	// Validate URL format and enforce HTTPS (unless MEDIAWIKI_ALLOW_INSECURE=true)
+	allowInsecure, _ := strconv.ParseBool(os.Getenv("MEDIAWIKI_ALLOW_INSECURE"))
+	if err := validateWikiURL(baseURL, allowInsecure); err != nil {
 		return nil, err
 	}
 
@@ -116,8 +117,8 @@ Examples:
 	}, nil
 }
 
-// validateWikiURL validates the wiki URL format and enforces HTTPS
-func validateWikiURL(rawURL string) error {
+// validateWikiURL validates the wiki URL format and enforces HTTPS unless allowInsecure is set
+func validateWikiURL(rawURL string, allowInsecure bool) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return &ConfigError{
@@ -130,8 +131,8 @@ Example:
 		}
 	}
 
-	// Enforce HTTPS for security (credentials are transmitted)
-	if parsed.Scheme != "https" {
+	// Enforce HTTPS for security (credentials are transmitted), unless explicitly opted out
+	if parsed.Scheme != "https" && !allowInsecure {
 		return &ConfigError{
 			Field:   "MEDIAWIKI_URL",
 			Message: fmt.Sprintf("URL must use HTTPS for security (got %q scheme)", parsed.Scheme),
@@ -142,6 +143,18 @@ Fixed:    ` + strings.Replace(rawURL, "http://", "https://", 1) + `
 
 If your wiki doesn't support HTTPS, set MEDIAWIKI_ALLOW_INSECURE=true
 (not recommended for production use).`,
+		}
+	}
+
+	// Only http and https are accepted, even with allowInsecure
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return &ConfigError{
+			Field:   "MEDIAWIKI_URL",
+			Message: fmt.Sprintf("URL scheme must be http or https (got %q)", parsed.Scheme),
+			Suggestion: `Provide a valid URL to your wiki's API endpoint.
+
+Example:
+  export MEDIAWIKI_URL="https://wiki.example.com/api.php"`,
 		}
 	}
 

--- a/wiki/errors_test.go
+++ b/wiki/errors_test.go
@@ -350,22 +350,25 @@ func TestConfigError_Error(t *testing.T) {
 
 func TestValidateWikiURL(t *testing.T) {
 	tests := []struct {
-		name        string
-		url         string
-		expectError bool
-		errorMsg    string
+		name          string
+		url           string
+		allowInsecure bool
+		expectError   bool
+		errorMsg      string
 	}{
-		{"Valid HTTPS", "https://wiki.example.com/api.php", false, ""},
-		{"Valid HTTPS with path", "https://wiki.example.com/w/api.php", false, ""},
-		{"HTTP rejected", "http://wiki.example.com/api.php", true, "HTTPS"},
-		{"Missing api.php", "https://wiki.example.com/", true, "api.php"},
-		{"Invalid URL no scheme", "not-a-url", true, "HTTPS"}, // Go parses with empty scheme
-		{"Empty scheme", "://wiki.example.com/api.php", true, ""},
+		{"Valid HTTPS", "https://wiki.example.com/api.php", false, false, ""},
+		{"Valid HTTPS with path", "https://wiki.example.com/w/api.php", false, false, ""},
+		{"HTTP rejected", "http://wiki.example.com/api.php", false, true, "HTTPS"},
+		{"HTTP allowed with opt-in", "http://wiki.example.com/api.php", true, false, ""},
+		{"Missing api.php", "https://wiki.example.com/", false, true, "api.php"},
+		{"Invalid URL no scheme", "not-a-url", false, true, "HTTPS"}, // Go parses with empty scheme
+		{"Empty scheme", "://wiki.example.com/api.php", false, true, ""},
+		{"Invalid scheme rejected even with opt-in", "ftp://wiki.example.com/api.php", true, true, "http or https"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateWikiURL(tt.url)
+			err := validateWikiURL(tt.url, tt.allowInsecure)
 			if tt.expectError && err == nil {
 				t.Errorf("Expected error for URL %q", tt.url)
 			}


### PR DESCRIPTION
## Summary

- The error message for non-HTTPS URLs told users to set `MEDIAWIKI_ALLOW_INSECURE=true`, but the variable was never read anywhere in the codebase — the only mention was the literal string inside the error suggestion text.
- `LoadConfig` now reads `MEDIAWIKI_ALLOW_INSECURE` via `strconv.ParseBool` and forwards it to `validateWikiURL`, which skips the HTTPS check when opted in.
- Schemes other than `http`/`https` are still rejected even with the opt-in, so `ftp://`/empty-scheme/etc. don't slip through.

Closes #54

## Test plan

- [x] `go test -race -failfast ./...` (full suite passes)
- [x] `golangci-lint run ./wiki/` (clean)
- [x] End-to-end verification of all branches via a throwaway `LoadConfig` driver:
  - `http://…` + unset → error ✓
  - `http://…` + `true` → success ✓
  - `https://…` + `true` → success ✓
  - `http://…` + `false` → error ✓
  - `ftp://…` + `true` → error (invalid scheme) ✓
  - `https://…` + unset → success ✓
- [x] New test cases added to `TestValidateWikiURL` covering the opt-in path and the invalid-scheme-with-opt-in rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)