### PR TITLE
fix(handlers): silent-nil dispatcher writes panic to *errPtr (HIGH severity for write tools)

### DIFF
--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -242,6 +244,14 @@ func (h *HandlerRegistry) buildTool(spec ToolSpec) *mcp.Tool {
 
 // register wraps a typed client method with panic recovery, metrics, tracing,
 // and logging, then attaches it to the MCP server.
+//
+// The dispatcher closure uses NAMED return values so the deferred recoverPanic
+// can reassign `err` on panic. Without named returns, Go cannot mutate the
+// return values from a deferred function and a panic-then-recover would surface
+// as `(nil, zero, nil)` to the MCP caller — looking like a successful empty
+// response. This is especially dangerous for destructive write tools (EditPage,
+// BulkReplace, MovePage) where masked-failure-as-success is silently destructive.
+// See HG-1 in rules/code-review-prompts.md.
 func register[Args, Result any](
 	h *HandlerRegistry,
 	server *mcp.Server,
@@ -249,8 +259,8 @@ func register[Args, Result any](
 	spec ToolSpec,
 	method func(context.Context, Args) (Result, error),
 ) {
-	mcp.AddTool(server, tool, func(ctx context.Context, req *mcp.CallToolRequest, args Args) (*mcp.CallToolResult, Result, error) {
-		defer h.recoverPanic(spec.Name)
+	mcp.AddTool(server, tool, func(ctx context.Context, req *mcp.CallToolRequest, args Args) (res *mcp.CallToolResult, out Result, err error) {
+		defer h.recoverPanic(spec.Name, &err)
 
 		ctx, span := tracing.StartSpan(ctx, "mcp.tool."+spec.Name)
 		defer span.End()
@@ -288,15 +298,40 @@ func register[Args, Result any](
 	})
 }
 
-// recoverPanic recovers from panics in tool handlers.
-func (h *HandlerRegistry) recoverPanic(toolName string) {
-	if rec := recover(); rec != nil {
-		metrics.PanicsRecovered.WithLabelValues(toolName).Inc()
-		h.logger.Error("Panic recovered",
-			"tool", toolName,
-			"panic", rec,
-			"stack", string(debug.Stack()))
+// recoverPanic recovers from panics in tool handlers and converts them into a
+// structured error with a correlation ID. The panic value and stack are logged
+// server-side; only the correlation ID reaches the MCP caller.
+//
+// MUST be called as `defer h.recoverPanic(spec.Name, &err)` from a function
+// with NAMED return values. Without named returns the deferred reassignment
+// is a no-op and panics surface as silent fake-success responses — a HIGH
+// severity failure mode for destructive write tools (EditPage, BulkReplace,
+// MovePage) where masked-failure-as-success is silently destructive.
+func (h *HandlerRegistry) recoverPanic(toolName string, errPtr *error) {
+	rec := recover()
+	if rec == nil {
+		return
 	}
+	corrID := newCorrelationID()
+	metrics.PanicsRecovered.WithLabelValues(toolName).Inc()
+	h.logger.Error("Panic recovered",
+		"tool", toolName,
+		"correlation_id", corrID,
+		"panic", rec,
+		"stack", string(debug.Stack()))
+	if errPtr != nil {
+		*errPtr = fmt.Errorf("%s: internal error (correlation_id=%s)", toolName, corrID)
+	}
+}
+
+// newCorrelationID returns a short hex string for log correlation. Falls back
+// to a timestamp-based ID if crypto/rand is unavailable (vanishingly rare).
+func newCorrelationID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // logExecution logs tool execution details. Rationale is always logged

--- a/tools/handlers_test.go
+++ b/tools/handlers_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/olgasafonova/mediawiki-mcp-server/wiki"
@@ -132,13 +133,42 @@ func TestRecoverPanic(t *testing.T) {
 
 	registry := NewHandlerRegistry(client, logger)
 
-	// Test that recoverPanic doesn't panic itself
+	// Test that recoverPanic doesn't panic itself, and that it writes a
+	// structured error to *errPtr so the MCP caller sees an error rather
+	// than a silent (nil, zero, nil) fake-success response. This is the
+	// HG-1 contract for destructive write tools (EditPage, BulkReplace,
+	// MovePage) where masked failure is silently destructive.
+	var gotErr error
 	func() {
-		defer registry.recoverPanic("test_tool")
+		defer registry.recoverPanic("test_tool", &gotErr)
 		panic("test panic")
 	}()
 
-	// If we get here, panic was recovered successfully
+	if gotErr == nil {
+		t.Fatal("recoverPanic must write a non-nil error to *errPtr; got nil (silent-nil dispatcher bug)")
+	}
+	if !strings.Contains(gotErr.Error(), "test_tool") {
+		t.Errorf("error should mention the tool name; got %q", gotErr.Error())
+	}
+	if !strings.Contains(gotErr.Error(), "correlation_id=") {
+		t.Errorf("error should include correlation_id for log correlation; got %q", gotErr.Error())
+	}
+
+	// Test the no-panic path: errPtr must not be touched when no panic.
+	var noPanicErr error
+	func() {
+		defer registry.recoverPanic("test_tool", &noPanicErr)
+		// no panic here
+	}()
+	if noPanicErr != nil {
+		t.Errorf("recoverPanic must not write to *errPtr when there is no panic; got %v", noPanicErr)
+	}
+
+	// Test nil errPtr safety: should not crash even if caller passes nil.
+	func() {
+		defer registry.recoverPanic("test_tool", nil)
+		panic("test panic with nil errPtr")
+	}()
 }
 
 func TestLogExecution(t *testing.T) {


### PR DESCRIPTION
## Summary
- `tools/handlers.go HandlerRegistry.recoverPanic` now takes a `*error` parameter and writes a structured `correlation_id`-bearing error on panic. The `register[Args, Result]` closure uses named returns `(res *mcp.CallToolResult, out Result, err error)` and `defer h.recoverPanic(spec.Name, &err)`. New `newCorrelationID` helper (`crypto/rand` 8-byte hex, timestamp fallback) provides the identifier.
- Closes a HIGH-severity silent-nil dispatcher: panics during write tools (`EditPage`, `BulkReplace`, `MovePage`) previously returned `(nil, zero, nil)` to the MCP caller, so a panic during a destructive write silently reported SUCCESS. This is masked-failure-as-success on a wiki — silently destructive.
- `TestRecoverPanic` extended to assert the contract on three paths: panic with errPtr, no-panic, nil errPtr.

## Background

Surfaced by audit-trio Stage 1 (23-05-2026), an audit fan-out across the MCP portfolio. Knowledge notes in vault under `AI-Knowledge/MCP Portfolio *`. Per `rules/code-review-prompts.md` HG-1 (panic recovery must convert to structured tool error). 1st occurrence of this pattern in `rules/review-patterns.md`; with the simultaneous nordic-registry fix the pattern clears graduation threshold.

Dispatcher-level coverage-assertion test deferred to follow-up. The SDK doesn't expose registered closures cleanly; would need >30 LOC scaffolding.

## Test plan

- [ ] CI: `go test -race -failfast ./...`
- [ ] CI: `golangci-lint run ./...`
- [ ] CI: `govulncheck ./...` (if configured)
- [ ] Manual review

Local verify clean (7/7 packages green, lint clean, build clean) on worktree at branch HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)