### PR TITLE
ci: drop binary upload from ci.yml (saves Free-tier Actions storage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,4 +139,3 @@ jobs:
             ext=".exe"
           fi
           go build -ldflags="-s -w" -o mediawiki-mcp-server-${{ matrix.goos }}-${{ matrix.goarch }}${ext} .
-          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,4 @@ jobs:
             ext=".exe"
           fi
           go build -ldflags="-s -w" -o mediawiki-mcp-server-${{ matrix.goos }}-${{ matrix.goarch }}${ext} .
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: mediawiki-mcp-server-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: mediawiki-mcp-server-${{ matrix.goos }}-${{ matrix.goarch }}*
           retention-days: 7


### PR DESCRIPTION
## Summary
- Removes the `upload-artifact` step from `ci.yml` build matrix; the build step itself stays as a cross-compile smoke test (still catches darwin/linux/windows breakage at compile time)
- `release.yml` is untouched — tagged releases still produce and upload downloadable binaries
- Recovers GitHub Actions storage on Free tier (500 MB cap); these CI-upload artifacts had no consumer

## Why
Cross-platform binaries uploaded on every push and PR with the default 90-day retention. Across the MCP server portfolio, ci.yml uploads were the dominant consumer of the Free-tier 500 MB storage budget. `release.yml` is independent and handles the real downloadable binaries on tagged releases.

## Test plan
- [x] YAML still parses (verified locally with `python3 -c "yaml.safe_load(...)"`)
- [ ] CI passes on this branch (test + lint + build matrix still run; nothing depends on the removed upload step)
- [ ] No external workflow consumed these ci.yml artifacts (manual confirm — release.yml is independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)