### PR TITLE
fix(edit): surface API failure details (CAPTCHA, info) and show in CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to MediaWiki MCP Server are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **`wiki edit` no longer reports a false success when an edit is blocked.** The MediaWiki edit API returns `result: "Failure"` inside a `200 OK` body when a CAPTCHA (ConfirmEdit) or AbuseFilter blocks the edit. The CLI previously checked only the new-page flag and printed `Edited <page> (rev: 0)`. It now prints `Failed to edit <page>: <reason>`, and the client surfaces the CAPTCHA type and `info` reason in the message (e.g. `Edit failed: Failure (CAPTCHA: simple)`). The MCP path already exposed `success: false` via structured content; this fixes the human-readable CLI surface. Thanks to @strk for the fix.
+
 ## [1.31.0] - 2026-05-14
 
 ### Added

--- a/cmd/wiki/edit.go
+++ b/cmd/wiki/edit.go
@@ -76,7 +76,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Human-readable output
-	if result.NewPage {
+	if !result.Success {
+		fmt.Printf("Failed to edit %s: %s\n", result.Title, result.Message)
+	} else if result.NewPage {
 		fmt.Printf("Created %s (rev: %d)\n", result.Title, result.RevisionID)
 	} else {
 		fmt.Printf("Edited %s (rev: %d)\n", result.Title, result.RevisionID)

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -120,7 +120,7 @@ func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult
 	if status := getString(edit["result"]); status != "Success" {
 		msg := fmt.Sprintf("Edit failed: %s", status)
 		if info := getString(edit["info"]); info != "" {
-			msg += fmt.Sprintf(" — %s", info)
+			msg += fmt.Sprintf(" - %s", info)
 		}
 		if captcha := getMap(edit["captcha"]); captcha != nil {
 			msg += fmt.Sprintf(" (CAPTCHA: %s)", getString(captcha["type"]))

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -118,15 +118,21 @@ func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult
 	}
 
 	if status := getString(edit["result"]); status != "Success" {
+		msg := fmt.Sprintf("Edit failed: %s", status)
+		if info := getString(edit["info"]); info != "" {
+			msg += fmt.Sprintf(" — %s", info)
+		}
+		if captcha := getMap(edit["captcha"]); captcha != nil {
+			msg += fmt.Sprintf(" (CAPTCHA: %s)", getString(captcha["type"]))
+		}
 		c.logAudit(c.buildAuditEntry(
 			AuditOpEdit, args.Title, args.Content, args.Summary,
-			args.Minor, args.Bot, false, 0, 0,
-			fmt.Sprintf("Edit failed: %s", status),
+			args.Minor, args.Bot, false, 0, 0, msg,
 		))
 		return EditResult{
 			Success: false,
 			Title:   args.Title,
-			Message: fmt.Sprintf("Edit failed: %s", status),
+			Message: msg,
 		}, nil
 	}
 

--- a/wiki/write_test.go
+++ b/wiki/write_test.go
@@ -251,6 +251,69 @@ func TestEditPage_EditFailed(t *testing.T) {
 	}
 }
 
+// TestEditPage_EditFailedDetails covers the failure-message enrichment: the
+// MediaWiki edit API returns result="Failure" inside a 200 body when a CAPTCHA
+// (ConfirmEdit) or AbuseFilter blocks the edit. The message must surface the
+// captcha type and the info reason so the CLI/agent sees why the edit failed
+// instead of a bare "Edit failed: Failure".
+func TestEditPage_EditFailedDetails(t *testing.T) {
+	tests := []struct {
+		name      string
+		edit      map[string]interface{}
+		wantParts []string
+	}{
+		{
+			name: "captcha",
+			edit: map[string]interface{}{
+				"result":  "Failure",
+				"captcha": map[string]interface{}{"type": "simple", "id": "1234"},
+			},
+			wantParts: []string{"Edit failed: Failure", "(CAPTCHA: simple)"},
+		},
+		{
+			name: "info",
+			edit: map[string]interface{}{
+				"result": "Failure",
+				"info":   "Hit AbuseFilter rule",
+			},
+			wantParts: []string{"Edit failed: Failure", "Hit AbuseFilter rule"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.FormValue("action") == "edit" {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"edit": tt.edit})
+					return
+				}
+				w.WriteHeader(http.StatusBadRequest)
+			})
+			defer server.Close()
+
+			client := createMockClient(t, server)
+			defer client.Close()
+
+			result, err := client.EditPage(context.Background(), EditPageArgs{
+				Title:   "Test Page",
+				Content: "Content",
+			})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if result.Success {
+				t.Error("Expected success to be false")
+			}
+			for _, part := range tt.wantParts {
+				if !strings.Contains(result.Message, part) {
+					t.Errorf("Message = %q, want substring %q", result.Message, part)
+				}
+			}
+		})
+	}
+}
+
 func TestEditPage_BadTokenRetry(t *testing.T) {
 	attempts := 0
 	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# Agent snippet

Previously, when an edit failed (e.g. due to a CAPTCHA), the CLI would
show a misleading success message like "Edited ScriptBasedPageCreateTest (rev: 0)".
This happened because the API can return a "result" field set to "Failure"
alongside a CAPTCHA requirement, but the client only checked for "Success"
and otherwise always reported success.

This change:
1. Checks `result.Success` in the CLI output to show failure messages
2. Includes CAPTCHA type and additional info (when present) in the error message

Now the output correctly displays:
```
Failed to edit ScriptBasedPageCreateTest: Edit failed: Failure (CAPTCHA: simple)
```

# Human snippet

This was vibe-coded using OpenCode 1.14.30 pointed at OpenCode Zen using Big Pickle model.
I reviewed the changes which are very small and I tested the result, which is now:
```
Failed to edit ScriptBasedPageCreateTest: Edit failed: Failure (CAPTCHA: simple)
```