### PR TITLE
feat(edit): add -f/--file flag to read wikitext from a file path

### DIFF
--- a/cmd/wiki/edit.go
+++ b/cmd/wiki/edit.go
@@ -15,15 +15,17 @@ func newEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit <title>",
 		Short: "Create or edit a wiki page",
-		Long: `Edit a wiki page with new content. Content can be provided via --content flag
-or piped from stdin:
+		Long: `Edit a wiki page with new content. Content can be provided via --content flag,
+--file flag, or piped from stdin:
 
   wiki edit "Page Title" --content "= Hello ="
+  wiki edit "Page Title" --file page.wiki --summary "Update from file"
   cat page.wiki | wiki edit "Page Title" --summary "Update from file"`,
 		Args: cobra.ExactArgs(1),
 		RunE: runEdit,
 	}
 
+	cmd.Flags().StringP("file", "f", "", "Path to file containing wikitext content")
 	cmd.Flags().String("content", "", "Page content in wikitext format")
 	cmd.Flags().String("summary", "", "Edit summary explaining the change")
 	cmd.Flags().Bool("minor", false, "Mark as minor edit")
@@ -52,6 +54,18 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		content, err = readStdin()
 		if err != nil {
 			return fmt.Errorf("failed to read stdin: %w", err)
+		}
+	}
+
+	// If still empty, try --file
+	if content == "" {
+		filePath, _ := cmd.Flags().GetString("file")
+		if filePath != "" {
+			fileBytes, err := os.ReadFile(filePath)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+			content = string(fileBytes)
 		}
 	}
 

--- a/cmd/wiki/edit.go
+++ b/cmd/wiki/edit.go
@@ -49,23 +49,23 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	bot, _ := cmd.Flags().GetBool("bot")
 	section, _ := cmd.Flags().GetString("section")
 
-	// If --content is empty, try reading from stdin
-	if content == "" {
-		content, err = readStdin()
-		if err != nil {
-			return fmt.Errorf("failed to read stdin: %w", err)
-		}
-	}
-
-	// If still empty, try --file
+	// If --content is empty, try --file
 	if content == "" {
 		filePath, _ := cmd.Flags().GetString("file")
 		if filePath != "" {
-			fileBytes, err := os.ReadFile(filePath)
+			fileBytes, err := os.ReadFile(filePath) // #nosec G304 -- path supplied via CLI flag by the invoking user
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}
 			content = string(fileBytes)
+		}
+	}
+
+	// If still empty, try reading from stdin
+	if content == "" {
+		content, err = readStdin()
+		if err != nil {
+			return fmt.Errorf("failed to read stdin: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Add a `-f/--file` flag to `wiki edit` so content can be read from a file
path instead of only via `--content` or stdin.

I needed this because my credential wrapper prompts for a password on
stdin, which conflicts with piping content through stdin. With `--file`,
the wrapper can prompt interactively while the content comes from a file.

I tested the result and read through the code — the changes are small
and correct.

This was vibe-coded using OpenCode 1.14.30 pointed at OpenCode Zen using
Big Pickle model.