### PR TITLE
feat(cli): add --verbose/-v flag with debug logging for API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to MediaWiki MCP Server are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`wiki` CLI `--verbose` / `-v` flag.** Lowers the logger level from `Warn` to `Debug`, making existing debug/info log lines visible. Also adds new `Debug` log lines showing the API action, URL, and attempt count before each request, plus response status and redacted body preview (token fields like `logintoken`/`csrftoken` are replaced with `[REDACTED]`). Thanks to @strk for the feature.
+
 ### Fixed
 - **Stale session cookies no longer cause login failures.** When a cached session (loaded via `RestoreSession`) has expired cookies, `checkExistingSession()` correctly fails, but the stale cookies remained in the jar. The subsequent login token request ran with those stale cookies, causing "Unable to continue login. Your session most likely timed out." from the wiki. The fix calls `resetCookies()` when `checkExistingSession()` returns false, so the login flow starts with a clean jar. Thanks to @strk for the fix.
 - **`wiki edit` no longer reports a false success when an edit is blocked.** The MediaWiki edit API returns `result: "Failure"` inside a `200 OK` body when a CAPTCHA (ConfirmEdit) or AbuseFilter blocks the edit. The CLI previously checked only the new-page flag and printed `Edited <page> (rev: 0)`. It now prints `Failed to edit <page>: <reason>`, and the client surfaces the CAPTCHA type and `info` reason in the message (e.g. `Edit failed: Failure (CAPTCHA: simple)`). The MCP path already exposed `success: false` via structured content; this fixes the human-readable CLI surface. Thanks to @strk for the fix.

--- a/cmd/wiki/client.go
+++ b/cmd/wiki/client.go
@@ -28,9 +28,13 @@ func newWikiClient(cmd *cobra.Command) (*wiki.Client, error) {
 		return nil, fmt.Errorf("configuration error: %w", err)
 	}
 
-	// CLI uses a quiet logger; MCP server is chattier
+	// CLI logger level
+	logLevel := slog.LevelWarn
+	if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+		logLevel = slog.LevelDebug
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelWarn,
+		Level: logLevel,
 	}))
 
 	client := wiki.NewClient(cfg, logger)

--- a/cmd/wiki/main.go
+++ b/cmd/wiki/main.go
@@ -29,6 +29,7 @@ func main() {
 	root.PersistentFlags().String("url", "", "Wiki API URL (overrides MEDIAWIKI_URL)")
 	root.PersistentFlags().Bool("json", false, "Output as JSON")
 	root.PersistentFlags().BoolP("quiet", "q", false, "Suppress non-essential output")
+	root.PersistentFlags().BoolP("verbose", "v", false, "Verbose output (debug logging)")
 
 	// Register commands
 	root.AddCommand(

--- a/wiki/client.go
+++ b/wiki/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -16,6 +17,9 @@ import (
 
 	"github.com/olgasafonova/mediawiki-mcp-server/metrics"
 )
+
+// tokenPattern matches token values in API response bodies for redaction in debug logs.
+var tokenPattern = regexp.MustCompile(`"(?:logintoken|csrftoken)":"[^"]*"`)
 
 // CacheEntry holds cached data with expiration and LRU tracking
 type CacheEntry struct {
@@ -346,6 +350,11 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 		// Note: Don't set Accept-Encoding manually - Go's http.Transport handles
 		// compression automatically when DisableCompression is false
 
+		c.logger.Debug("API request",
+			"action", action,
+			"url", c.config.BaseURL,
+			"attempt", attempt+1)
+
 		resp, err := c.httpClient.Do(req) // #nosec G704 -- URL is the configured wiki API endpoint, not user-controlled
 		if err != nil {
 			lastErr = fmt.Errorf("request failed: %w", err)
@@ -366,6 +375,9 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 
 		// Handle different status codes appropriately
 		if resp.StatusCode != http.StatusOK {
+			c.logger.Debug("API non-OK response",
+				"status", resp.StatusCode,
+				"body_preview", redactTokens(string(body[:min(len(body), 500)])))
 			retryable, err := c.handleNonOKResponse(ctx, resp, body, attempt)
 			if !retryable {
 				return nil, err
@@ -373,6 +385,10 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 			lastErr = err
 			continue
 		}
+
+		c.logger.Debug("API response",
+			"status", resp.StatusCode,
+			"body_preview", redactTokens(string(body[:min(len(body), 500)])))
 
 		var result map[string]interface{}
 		if err := json.Unmarshal(body, &result); err != nil {
@@ -412,3 +428,8 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 // after use, so we must not reuse them across edit requests.
 // EnsureLoggedIn ensures the client is logged in (for wikis requiring auth for read)
 // truncateContent truncates content if it exceeds the limit
+
+// redactTokens replaces token values in a JSON response string for safe debug logging.
+func redactTokens(s string) string {
+	return tokenPattern.ReplaceAllString(s, `"$1":"[REDACTED]"`)
+}


### PR DESCRIPTION
Add a `--verbose` / `-v` global flag to the `wiki` CLI that lowers the
logger level from `Warn` to `Debug`, making existing debug/info log lines
visible. Also adds new `Debug` log lines in `apiRequest` showing the
action, URL, and response status + first 500 bytes of body for each API
call.

This was needed to diagnose authentication failures like:
```
Error: authentication failed: login failed: Failed - Unable to continue
login. Your session most likely timed out.
```

With `--verbose`, the actual API request/response and session state are
visible, making it possible to diagnose the root cause.

This was vibe-coded using OpenCode 1.14.30 pointed at OpenCode Zen using
Big Pickle model. I reviewed and tested the changes.