### PR TITLE
fix(login): clear stale cookies before login to prevent session timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to MediaWiki MCP Server are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **Stale session cookies no longer cause login failures.** When a cached session (loaded via `RestoreSession`) has expired cookies, `checkExistingSession()` correctly fails, but the stale cookies remained in the jar. The subsequent login token request ran with those stale cookies, causing "Unable to continue login. Your session most likely timed out." from the wiki. The fix calls `resetCookies()` when `checkExistingSession()` returns false, so the login flow starts with a clean jar. Thanks to @strk for the fix.
 - **`wiki edit` no longer reports a false success when an edit is blocked.** The MediaWiki edit API returns `result: "Failure"` inside a `200 OK` body when a CAPTCHA (ConfirmEdit) or AbuseFilter blocks the edit. The CLI previously checked only the new-page flag and printed `Edited <page> (rev: 0)`. It now prints `Failed to edit <page>: <reason>`, and the client surfaces the CAPTCHA type and `info` reason in the message (e.g. `Edit failed: Failure (CAPTCHA: simple)`). The MCP path already exposed `success: false` via structured content; this fixes the human-readable CLI surface. Thanks to @strk for the fix.
 
 ## [1.31.0] - 2026-05-14

--- a/wiki/client.go
+++ b/wiki/client.go
@@ -406,6 +406,7 @@ func (c *Client) apiRequest(ctx context.Context, params url.Values) (map[string]
 // Returns true if already authenticated, false otherwise
 // resetCookies clears all cookies to allow fresh login
 // login authenticates with the wiki using bot password
+
 // loginFresh performs login with guaranteed fresh cookies (no retry)
 // getCSRFToken gets a CSRF token for editing
 // after use, so we must not reuse them across edit requests.

--- a/wiki/client_auth.go
+++ b/wiki/client_auth.go
@@ -79,6 +79,12 @@ func (c *Client) login(ctx context.Context) error {
 		return nil
 	}
 
+	// No valid session — clear leftover cookies from RestoreSession so the
+	// login token request and login call share a clean session. Stale cookies
+	// would otherwise cause "Unable to continue login. Your session most
+	// likely timed out." from the wiki.
+	c.resetCookies()
+
 	// Get login token
 	params := url.Values{}
 	params.Set("action", "query")

--- a/wiki/client_test.go
+++ b/wiki/client_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -1299,6 +1301,89 @@ func TestLogin_NeedToken(t *testing.T) {
 
 	// Exercises the NeedToken path
 	t.Logf("Login NeedToken result: err=%v, requestCount=%d", err, requestCount)
+}
+
+func TestLogin_ResetsCookiesOnNoSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		action := r.FormValue("action")
+
+		if action == "query" {
+			meta := r.FormValue("meta")
+			if meta == "userinfo" {
+				// Return anon (no valid session) so checkExistingSession fails
+				response := map[string]interface{}{
+					"query": map[string]interface{}{
+						"userinfo": map[string]interface{}{
+							"id":   float64(0),
+							"name": "",
+							"anon": "",
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+				return
+			}
+			if meta == "tokens" && r.FormValue("type") == "login" {
+				response := map[string]interface{}{
+					"query": map[string]interface{}{
+						"tokens": map[string]interface{}{
+							"logintoken": "test-login-token+\\",
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+				return
+			}
+		}
+
+		if action == "login" {
+			response := map[string]interface{}{
+				"login": map[string]interface{}{
+					"result":     "Success",
+					"lguserid":   float64(1),
+					"lgusername": "TestUser",
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"query":{}}`))
+	}))
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	// Seed a stale cookie into the jar (simulates expired RestoreSession)
+	jarURL, _ := url.Parse(server.URL)
+	client.httpClient.Jar.SetCookies(jarURL, []*http.Cookie{
+		{Name: "stale_session", Value: "expired", Path: "/"},
+	})
+
+	ctx := context.Background()
+	err := client.login(ctx)
+	if err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+	if !client.loggedIn {
+		t.Error("Expected loggedIn = true after successful login")
+	}
+
+	// Verify the stale cookie was cleared (the jar was reset before the login
+	// token request, so the only cookies present are from the login response)
+	cookies := client.httpClient.Jar.Cookies(jarURL)
+	t.Logf("Cookies in jar after login: %v", cookies)
+	for _, c := range cookies {
+		if c.Name == "stale_session" {
+			t.Error("stale_session cookie should have been cleared by resetCookies()")
+		}
+	}
 }
 
 func TestCSRFToken(t *testing.T) {


### PR DESCRIPTION
When a cached session (loaded via `RestoreSession`) has expired cookies,
`checkExistingSession()` correctly fails, but the stale cookies remain
in the jar. The subsequent "get login token" request then runs with those
stale cookies, and the actual login call gets "Unable to continue login.
Your session most likely timed out." because the wiki sees conflicting
session state.

The fix: call `resetCookies()` when `checkExistingSession()` returns
false, so the login flow starts with a clean jar and a consistent
session across the token request and login call.

This was vibe-coded using OpenCode 1.14.30 pointed at OpenCode Zen using
Big Pickle model. I reviewed the changes and tested the fix — without
`WIKI_NO_SESSION_CACHE=1`, the wiki CLI now authenticates correctly
instead of failing with the session timeout error.