### PR TITLE
feat(wiki): interactive CAPTCHA prompting for edit and publish CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to MediaWiki MCP Server are documented here.
 
 ### Added
 - **`wiki` CLI `--verbose` / `-v` flag.** Lowers the logger level from `Warn` to `Debug`, making existing debug/info log lines visible. Also adds new `Debug` log lines showing the API action, URL, and attempt count before each request, plus response status and redacted body preview (token fields like `logintoken`/`csrftoken` are replaced with `[REDACTED]`). Thanks to @strk for the feature.
+- **Interactive CAPTCHA prompting for `edit` and `publish` CLI commands.** When a CAPTCHA is required, the CLI now prompts interactively via `/dev/tty` (or stdin as fallback) for the answer and retries the request. Plain-text non-interactive mode (CI/piped stdin) exits with a hint instead of looping infinitely. Thanks to @strk for the implementation.
 
 ### Fixed
 - **Stale session cookies no longer cause login failures.** When a cached session (loaded via `RestoreSession`) has expired cookies, `checkExistingSession()` correctly fails, but the stale cookies remained in the jar. The subsequent login token request ran with those stale cookies, causing "Unable to continue login. Your session most likely timed out." from the wiki. The fix calls `resetCookies()` when `checkExistingSession()` returns false, so the login flow starts with a clean jar. Thanks to @strk for the fix.

--- a/cmd/wiki/edit.go
+++ b/cmd/wiki/edit.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -73,7 +74,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("content is required (use --content or pipe from stdin)")
 	}
 
-	result, err := client.EditPage(context.Background(), wiki.EditPageArgs{
+	result, err := client.EditPage(cmd.Context(), wiki.EditPageArgs{
 		Title:   title,
 		Content: content,
 		Summary: summary,
@@ -83,6 +84,14 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("edit failed: %w", err)
+	}
+
+	// CAPTCHA retry loop
+	for !result.Success && result.CaptchaType != "" {
+		if isJSON(cmd) {
+			break
+		}
+		result = promptAndRetryCaptcha(cmd, client, title, content, summary, minor, bot, section, result)
 	}
 
 	if isJSON(cmd) {
@@ -99,6 +108,69 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// promptAndRetryCaptcha prompts the user for a CAPTCHA answer and retries
+// the edit. Tries /dev/tty first, then os.Stdin if it's a terminal. Prints
+// a hint to stderr when no interactive prompt is available.
+func promptAndRetryCaptcha(cmd *cobra.Command, client *wiki.Client, title, content, summary string, minor, bot bool, section string, original wiki.EditResult) wiki.EditResult {
+	question := original.CaptchaQuestion
+	if question == "" {
+		question = fmt.Sprintf("CAPTCHA type: %s", original.CaptchaType)
+	}
+
+	var in io.Reader
+	var out io.Writer
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err == nil {
+		defer tty.Close()
+		in = tty
+		out = tty
+	} else if info, statErr := os.Stdin.Stat(); statErr == nil && info.Mode()&os.ModeCharDevice != 0 {
+		in = os.Stdin
+		out = os.Stderr
+	}
+
+	if in != nil {
+		br := bufio.NewReader(in)
+		for {
+			fmt.Fprintf(out, "CAPTCHA required: %s\nAnswer: ", question)
+			line, readErr := br.ReadString('\n')
+			answer := strings.TrimSpace(line)
+			if readErr != nil && answer == "" {
+				break
+			}
+			if answer != "" {
+				return retryEditWithCaptcha(cmd.Context(), client, title, content, summary, minor, bot, section, original, answer)
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "CAPTCHA required but no interactive input available (pass --json to see CAPTCHA details)\n")
+	original.CaptchaType = ""
+	return original
+}
+
+func retryEditWithCaptcha(ctx context.Context, client *wiki.Client, title, content, summary string, minor, bot bool, section string, original wiki.EditResult, answer string) wiki.EditResult {
+	result, err := client.EditPage(ctx, wiki.EditPageArgs{
+		Title:       title,
+		Content:     content,
+		Summary:     summary,
+		Minor:       minor,
+		Bot:         bot,
+		Section:     section,
+		CaptchaID:   original.CaptchaID,
+		CaptchaWord: answer,
+	})
+	if err != nil {
+		return wiki.EditResult{
+			Success: false,
+			Title:   title,
+			Message: fmt.Sprintf("Edit failed on CAPTCHA retry: %v", err),
+		}
+	}
+
+	return result
 }
 
 // readStdin reads all available data from stdin if it's not a terminal.

--- a/cmd/wiki/publish.go
+++ b/cmd/wiki/publish.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -84,7 +83,7 @@ func runPublish(cmd *cobra.Command, args []string) error {
 		summary = fmt.Sprintf("Published from %s", filepath.Base(filePath))
 	}
 
-	result, err := client.EditPage(context.Background(), wiki.EditPageArgs{
+	result, err := client.EditPage(cmd.Context(), wiki.EditPageArgs{
 		Title:   pageTitle,
 		Content: wikitext,
 		Summary: summary,
@@ -94,8 +93,20 @@ func runPublish(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("publish failed: %w", err)
 	}
 
+	// CAPTCHA retry loop
+	for !result.Success && result.CaptchaType != "" {
+		if isJSON(cmd) {
+			break
+		}
+		result = promptAndRetryCaptcha(cmd, client, pageTitle, wikitext, summary, minor, false, "", result)
+	}
+
 	if isJSON(cmd) {
 		return printJSON(result)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("publish failed: %s", result.Message)
 	}
 
 	fmt.Printf("Published %s -> %s (rev: %d)\n", filepath.Base(filePath), result.Title, result.RevisionID)

--- a/wiki/client.go
+++ b/wiki/client.go
@@ -19,7 +19,7 @@ import (
 )
 
 // tokenPattern matches token values in API response bodies for redaction in debug logs.
-var tokenPattern = regexp.MustCompile(`"(?:logintoken|csrftoken)":"[^"]*"`)
+var tokenPattern = regexp.MustCompile(`"(logintoken|csrftoken)":"[^"]*"`)
 
 // CacheEntry holds cached data with expiration and LRU tracking
 type CacheEntry struct {

--- a/wiki/types_write.go
+++ b/wiki/types_write.go
@@ -5,22 +5,27 @@ package wiki
 // EditPageArgs contains parameters for creating or editing a wiki page.
 type EditPageArgs struct {
 	BaseWriteArgs
-	Title   string `json:"title" jsonschema:"Page title to edit or create"`
-	Content string `json:"content" jsonschema:"New page content in wikitext format"`
-	Summary string `json:"summary,omitempty" jsonschema:"Edit summary explaining the change"`
-	Minor   bool   `json:"minor,omitempty" jsonschema:"Mark as minor edit"`
-	Bot     bool   `json:"bot,omitempty" jsonschema:"Mark as bot edit (requires bot flag)"`
-	Section string `json:"section,omitempty" jsonschema:"Section to edit ('new' for new section, number for existing)"`
+	Title       string `json:"title" jsonschema:"Page title to edit or create"`
+	Content     string `json:"content" jsonschema:"New page content in wikitext format"`
+	Summary     string `json:"summary,omitempty" jsonschema:"Edit summary explaining the change"`
+	Minor       bool   `json:"minor,omitempty" jsonschema:"Mark as minor edit"`
+	Bot         bool   `json:"bot,omitempty" jsonschema:"Mark as bot edit (requires bot flag)"`
+	Section     string `json:"section,omitempty" jsonschema:"Section to edit ('new' for new section, number for existing)"`
+	CaptchaID   string `json:"captcha_id,omitempty" jsonschema:"CAPTCHA ID from a previous failed attempt, required when answering a CAPTCHA"`
+	CaptchaWord string `json:"captcha_word,omitempty" jsonschema:"User-provided answer to the CAPTCHA challenge"`
 }
 
 // EditResult contains the result of a page edit operation.
 type EditResult struct {
-	Success    bool   `json:"success"`
-	Title      string `json:"title"`
-	PageID     int    `json:"page_id"`
-	RevisionID int    `json:"revision_id"`
-	NewPage    bool   `json:"new_page"`
-	Message    string `json:"message"`
+	Success         bool   `json:"success"`
+	Title           string `json:"title"`
+	PageID          int    `json:"page_id"`
+	RevisionID      int    `json:"revision_id"`
+	NewPage         bool   `json:"new_page"`
+	Message         string `json:"message"`
+	CaptchaType     string `json:"captcha_type,omitempty"`
+	CaptchaID       string `json:"captcha_id,omitempty"`
+	CaptchaQuestion string `json:"captcha_question,omitempty"`
 }
 
 // EditRevisionInfo contains revision tracking info for edit operations

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -76,6 +76,12 @@ func buildEditAPIParams(args EditPageArgs, token string) url.Values {
 	if args.Section != "" {
 		params.Set("section", args.Section)
 	}
+	if args.CaptchaID != "" {
+		params.Set("captchaid", args.CaptchaID)
+	}
+	if args.CaptchaWord != "" {
+		params.Set("captchaword", args.CaptchaWord)
+	}
 	return params
 }
 
@@ -119,17 +125,24 @@ func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult
 		if info := getString(edit["info"]); info != "" {
 			msg += fmt.Sprintf(" - %s", info)
 		}
+		var captchaType, captchaID, captchaQuestion string
 		if captcha := getMap(edit["captcha"]); captcha != nil {
-			msg += fmt.Sprintf(" (CAPTCHA: %s)", getString(captcha["type"]))
+			captchaType = getString(captcha["type"])
+			captchaID = getString(captcha["id"])
+			captchaQuestion = getString(captcha["question"])
+			msg += fmt.Sprintf(" (CAPTCHA: %s)", captchaType)
 		}
 		c.logAudit(c.buildAuditEntry(
 			AuditOpEdit, args.Title, args.Content, args.Summary,
 			args.Minor, args.Bot, false, 0, 0, msg,
 		))
 		return EditResult{
-			Success: false,
-			Title:   args.Title,
-			Message: msg,
+			Success:         false,
+			Title:           args.Title,
+			Message:         msg,
+			CaptchaType:     captchaType,
+			CaptchaID:       captchaID,
+			CaptchaQuestion: captchaQuestion,
 		}, nil
 	}
 

--- a/wiki/write_test.go
+++ b/wiki/write_test.go
@@ -266,7 +266,7 @@ func TestEditPage_EditFailedDetails(t *testing.T) {
 			name: "captcha",
 			edit: map[string]interface{}{
 				"result":  "Failure",
-				"captcha": map[string]interface{}{"type": "simple", "id": "1234"},
+				"captcha": map[string]interface{}{"type": "simple", "id": "1234", "question": "What is 2+2?"},
 			},
 			wantParts: []string{"Edit failed: Failure", "(CAPTCHA: simple)"},
 		},
@@ -310,7 +310,58 @@ func TestEditPage_EditFailedDetails(t *testing.T) {
 					t.Errorf("Message = %q, want substring %q", result.Message, part)
 				}
 			}
+			if tt.name == "captcha" {
+				if result.CaptchaType != "simple" {
+					t.Errorf("CaptchaType = %q, want 'simple'", result.CaptchaType)
+				}
+				if result.CaptchaID != "1234" {
+					t.Errorf("CaptchaID = %q, want '1234'", result.CaptchaID)
+				}
+				if result.CaptchaQuestion != "What is 2+2?" {
+					t.Errorf("CaptchaQuestion = %q, want 'What is 2+2?'", result.CaptchaQuestion)
+				}
+			}
 		})
+	}
+}
+
+func TestEditPage_CaptchaArgsPassthrough(t *testing.T) {
+	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		action := r.FormValue("action")
+		if action == "edit" {
+			if r.FormValue("captchaid") != "789" {
+				t.Error("Expected captchaid=789 in API request")
+			}
+			if r.FormValue("captchaword") != "test-answer" {
+				t.Error("Expected captchaword=test-answer in API request")
+			}
+			response := map[string]interface{}{
+				"edit": map[string]interface{}{
+					"result":   "Success",
+					"pageid":   float64(123),
+					"title":    "Test Page",
+					"newrevid": float64(456),
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	_, err := client.EditPage(context.Background(), EditPageArgs{
+		Title:       "Test Page",
+		Content:     "Content",
+		CaptchaID:   "789",
+		CaptchaWord: "test-answer",
+	})
+	if err != nil {
+		t.Fatalf("EditPage failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `CaptchaID`/`CaptchaWord` fields to `EditPageArgs` and `CaptchaType`/`CaptchaID`/`CaptchaQuestion` to `EditResult` in `wiki/types_write.go`
- Forward `captchaid`/`captchaword` parameters in `buildEditAPIParams` (`wiki/write.go`)
- Populate CAPTCHA fields on edit failure in `performEdit` (`wiki/write.go`)
- Interactive CAPTCHA prompt in `cmd/wiki/edit.go` and `cmd/wiki/publish.go` with `/dev/tty` → `os.Stdin` → stderr fallback, retrying the edit with the user-provided answer
- Tests for CAPTCHA field population and captchaid/captchaword passthrough

*Note: vibe-coded with OpenCode 1.14.30 (OpenCode Zen, Big Pickle model)*