### PR TITLE
Print full page URL on successful edit in wiki CLI

### DIFF
--- a/cmd/wiki/edit.go
+++ b/cmd/wiki/edit.go
@@ -106,6 +106,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("Edited %s (rev: %d)\n", result.Title, result.RevisionID)
 	}
+	if result.Success && result.PageURL != "" {
+		fmt.Printf("URL: %s\n", result.PageURL)
+	}
 
 	return nil
 }

--- a/wiki/api_test.go
+++ b/wiki/api_test.go
@@ -626,6 +626,32 @@ func TestPageURL_PrettyFromSiteInfo(t *testing.T) {
 	}
 }
 
+func TestPageURL_SchemeRelativeServer(t *testing.T) {
+	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// MediaWiki can return server in scheme-relative form on some installs.
+		response := map[string]interface{}{
+			"query": map[string]interface{}{
+				"general": map[string]interface{}{
+					"server":      "//wiki.example.com",
+					"articlepath": "/wiki/$1",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	got := client.pageURL(context.Background(), "LLM-based Chat Assistant")
+	want := "http://wiki.example.com/wiki/LLM-based_Chat_Assistant"
+	if got != want {
+		t.Errorf("pageURL() = %q, want %q", got, want)
+	}
+}
+
 func TestPageURL_PreservesSubpageSlashes(t *testing.T) {
 	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
 		response := map[string]interface{}{

--- a/wiki/api_test.go
+++ b/wiki/api_test.go
@@ -600,6 +600,85 @@ func TestGetWikiInfo_Success(t *testing.T) {
 	}
 }
 
+func TestPageURL_PrettyFromSiteInfo(t *testing.T) {
+	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Only siteinfo matters here
+		response := map[string]interface{}{
+			"query": map[string]interface{}{
+				"general": map[string]interface{}{
+					"server":      "https://wiki.example.com",
+					"articlepath": "/wiki/$1",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	got := client.pageURL(context.Background(), "LLM-based Chat Assistant")
+	want := "https://wiki.example.com/wiki/LLM-based_Chat_Assistant"
+	if got != want {
+		t.Errorf("pageURL() = %q, want %q", got, want)
+	}
+}
+
+func TestPageURL_PreservesSubpageSlashes(t *testing.T) {
+	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"query": map[string]interface{}{
+				"general": map[string]interface{}{
+					"server":      "https://wiki.example.com",
+					"articlepath": "/wiki/$1",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	got := client.pageURL(context.Background(), "User:Alice/Sandbox")
+	want := "https://wiki.example.com/wiki/User:Alice/Sandbox"
+	if got != want {
+		t.Errorf("pageURL() = %q, want %q", got, want)
+	}
+}
+
+func TestPageURL_FallbackOnSiteInfoFailure(t *testing.T) {
+	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	got := client.pageURL(context.Background(), "Main Page")
+	want := server.URL + "/index.php?title=Main_Page"
+	if got != want {
+		t.Errorf("pageURL() = %q, want %q", got, want)
+	}
+}
+
+func TestPageURL_EmptyInputs(t *testing.T) {
+	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	defer server.Close()
+
+	client := createMockClient(t, server)
+	defer client.Close()
+
+	if got := client.pageURL(context.Background(), ""); got != "" {
+		t.Errorf("pageURL(\"\") = %q, want empty", got)
+	}
+}
+
 func TestGetPageInfo_Success(t *testing.T) {
 	server := mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
 		response := map[string]interface{}{

--- a/wiki/types_write.go
+++ b/wiki/types_write.go
@@ -22,6 +22,7 @@ type EditResult struct {
 	PageID          int    `json:"page_id"`
 	RevisionID      int    `json:"revision_id"`
 	NewPage         bool   `json:"new_page"`
+	PageURL         string `json:"page_url,omitempty"`
 	Message         string `json:"message"`
 	CaptchaType     string `json:"captcha_type,omitempty"`
 	CaptchaID       string `json:"captcha_id,omitempty"`

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -86,7 +86,7 @@ func buildEditAPIParams(args EditPageArgs, token string) url.Values {
 }
 
 // editResultFromAPI converts a successful edit API response into an EditResult.
-func editResultFromAPI(edit map[string]interface{}) EditResult {
+func (c *Client) editResultFromAPI(edit map[string]interface{}) EditResult {
 	r := EditResult{
 		Success:    true,
 		Title:      getString(edit["title"]),
@@ -98,6 +98,7 @@ func editResultFromAPI(edit map[string]interface{}) EditResult {
 	if r.NewPage {
 		r.Message = "Page created successfully"
 	}
+	r.PageURL = c.pageURL(r.Title)
 	return r
 }
 
@@ -146,7 +147,7 @@ func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult
 		}, nil
 	}
 
-	editResult := editResultFromAPI(edit)
+	editResult := c.editResultFromAPI(edit)
 	op := AuditOpEdit
 	if editResult.NewPage {
 		op = AuditOpCreate
@@ -490,6 +491,18 @@ func (c *Client) buildEditRevisionInfo(title string, oldRevision, newRevision in
 			Instruction: undoInstruction,
 			WikiURL:     undoURL,
 		}
+}
+
+// pageURL builds the human-readable page URL for the given title, derived
+// from the configured API endpoint (api.php -> index.php). Returns an empty
+// string if the title is empty or the API URL is unconfigured.
+func (c *Client) pageURL(title string) string {
+	if title == "" || c.config.BaseURL == "" {
+		return ""
+	}
+	wikiBaseURL := strings.TrimSuffix(c.config.BaseURL, "api.php") + "index.php"
+	encodedTitle := url.QueryEscape(strings.ReplaceAll(title, " ", "_"))
+	return fmt.Sprintf("%s?title=%s", wikiBaseURL, encodedTitle)
 }
 
 // extractNormalizedTitleMap reads the "normalized" array from a MediaWiki query

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -86,7 +86,10 @@ func buildEditAPIParams(args EditPageArgs, token string) url.Values {
 }
 
 // editResultFromAPI converts a successful edit API response into an EditResult.
-func (c *Client) editResultFromAPI(edit map[string]interface{}) EditResult {
+// It uses ctx to fetch (and cache) site info for building a pretty page URL;
+// any failure to obtain site info is non-fatal — the index.php?title= form
+// is used as a fallback.
+func (c *Client) editResultFromAPI(ctx context.Context, edit map[string]interface{}) EditResult {
 	r := EditResult{
 		Success:    true,
 		Title:      getString(edit["title"]),
@@ -98,7 +101,7 @@ func (c *Client) editResultFromAPI(edit map[string]interface{}) EditResult {
 	if r.NewPage {
 		r.Message = "Page created successfully"
 	}
-	r.PageURL = c.pageURL(r.Title)
+	r.PageURL = c.pageURL(ctx, r.Title)
 	return r
 }
 
@@ -147,7 +150,7 @@ func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult
 		}, nil
 	}
 
-	editResult := c.editResultFromAPI(edit)
+	editResult := c.editResultFromAPI(ctx, edit)
 	op := AuditOpEdit
 	if editResult.NewPage {
 		op = AuditOpCreate
@@ -493,16 +496,38 @@ func (c *Client) buildEditRevisionInfo(title string, oldRevision, newRevision in
 		}
 }
 
-// pageURL builds the human-readable page URL for the given title, derived
-// from the configured API endpoint (api.php -> index.php). Returns an empty
-// string if the title is empty or the API URL is unconfigured.
-func (c *Client) pageURL(title string) string {
+// pageURL builds the human-readable page URL for the given title.
+//
+// It tries to use the wiki's pretty URL form (e.g. /wiki/Foo_Bar) derived
+// from siteinfo's Server and ArticlePath (cached after the first call).
+// When siteinfo is unavailable, it falls back to the universal
+// index.php?title= form derived from the configured API endpoint.
+//
+// Returns an empty string if the title is empty or the API URL is
+// unconfigured.
+func (c *Client) pageURL(ctx context.Context, title string) string {
 	if title == "" || c.config.BaseURL == "" {
 		return ""
 	}
-	wikiBaseURL := strings.TrimSuffix(c.config.BaseURL, "api.php") + "index.php"
-	encodedTitle := url.QueryEscape(strings.ReplaceAll(title, " ", "_"))
-	return fmt.Sprintf("%s?title=%s", wikiBaseURL, encodedTitle)
+
+	pathTitle := strings.ReplaceAll(title, " ", "_")
+
+	if info, err := c.GetWikiInfo(ctx, WikiInfoArgs{}); err == nil && info.Server != "" && info.ArticlePath != "" {
+		if strings.Contains(info.ArticlePath, "$1") {
+			// Path-escape the title, then unescape slashes so subpage
+			// slashes survive (e.g. User:Alice/Sandbox stays as
+			// User:Alice/Sandbox, not User:Alice%2FSandbox).
+			escaped := strings.ReplaceAll(url.PathEscape(pathTitle), "%2F", "/")
+			return info.Server + strings.Replace(info.ArticlePath, "$1", escaped, 1)
+		}
+	}
+
+	wikiBaseURL := strings.TrimSuffix(c.config.BaseURL, "api.php")
+	if !strings.HasSuffix(wikiBaseURL, "/") {
+		wikiBaseURL += "/"
+	}
+	wikiBaseURL += "index.php"
+	return fmt.Sprintf("%s?title=%s", wikiBaseURL, url.QueryEscape(pathTitle))
 }
 
 // extractNormalizedTitleMap reads the "normalized" array from a MediaWiki query

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -503,6 +503,14 @@ func (c *Client) buildEditRevisionInfo(title string, oldRevision, newRevision in
 // When siteinfo is unavailable, it falls back to the universal
 // index.php?title= form derived from the configured API endpoint.
 //
+// MediaWiki's `server` field in siteinfo can be returned in three forms:
+//   - absolute:   "https://wiki.example.com"
+//   - scheme-less: "//wiki.example.com"  (some installations)
+//   - protocol-relative with a port:  "//wiki.example.com:443"
+//
+// In the scheme-less case we borrow the scheme from the configured API
+// endpoint so the printed URL is clickable from a terminal.
+//
 // Returns an empty string if the title is empty or the API URL is
 // unconfigured.
 func (c *Client) pageURL(ctx context.Context, title string) string {
@@ -514,11 +522,12 @@ func (c *Client) pageURL(ctx context.Context, title string) string {
 
 	if info, err := c.GetWikiInfo(ctx, WikiInfoArgs{}); err == nil && info.Server != "" && info.ArticlePath != "" {
 		if strings.Contains(info.ArticlePath, "$1") {
+			server := ensureServerScheme(info.Server, c.config.BaseURL)
 			// Path-escape the title, then unescape slashes so subpage
 			// slashes survive (e.g. User:Alice/Sandbox stays as
 			// User:Alice/Sandbox, not User:Alice%2FSandbox).
 			escaped := strings.ReplaceAll(url.PathEscape(pathTitle), "%2F", "/")
-			return info.Server + strings.Replace(info.ArticlePath, "$1", escaped, 1)
+			return server + strings.Replace(info.ArticlePath, "$1", escaped, 1)
 		}
 	}
 
@@ -528,6 +537,19 @@ func (c *Client) pageURL(ctx context.Context, title string) string {
 	}
 	wikiBaseURL += "index.php"
 	return fmt.Sprintf("%s?title=%s", wikiBaseURL, url.QueryEscape(pathTitle))
+}
+
+// ensureServerScheme returns server with a scheme. If server is scheme-relative
+// (e.g. "//wiki.example.com") the scheme from apiBase is prepended. Otherwise
+// server is returned unchanged.
+func ensureServerScheme(server, apiBase string) string {
+	if !strings.HasPrefix(server, "//") {
+		return server
+	}
+	if u, err := url.Parse(apiBase); err == nil && u.Scheme != "" {
+		return u.Scheme + ":" + server
+	}
+	return server
 }
 
 // extractNormalizedTitleMap reads the "normalized" array from a MediaWiki query


### PR DESCRIPTION
On success, the 'wiki edit' command now prints a 'URL:' line with the human-readable index.php link to the edited/created page, making it easier to review the outcome without digging into the title.

A new PageURL field is added to EditResult, populated via a new Client.pageURL helper that derives the page URL from the configured API endpoint. The URL is also exposed in --json output.

Co-Authored-By: OpenCode 1.14.50 / MiniMax-M3

I let the LLM write this, when I tested it I didn't like it too much that the printed URL wasn't clean, ie:
> URL: https://wiki.osgeo.org/w/index.php?title=LLM-based_Chat_Assistant

I would have preferred to see https://wiki.osgeo.org/wiki/LLM-based_Chat_Assistant - I think the code in this PR also goes finding the page URL with a new request, but I suppose it could be constructed from MEDIAWIKI_URL, am I wrong ?