### PR TITLE
refactor: raise CodeScene Code Health to Green (>=9.0)

### DIFF
--- a/evals/runner.go
+++ b/evals/runner.go
@@ -47,32 +47,48 @@ type ToolSelector interface {
 	SelectTool(input string) (toolName string, args map[string]interface{}, err error)
 }
 
-// EvaluateToolSelection runs tool selection tests against a selector
-func EvaluateToolSelection(suite *ToolSelectionSuite, selector ToolSelector) (*EvalMetrics, []ToolSelectionResult) {
-	metrics := &EvalMetrics{
+// newMetrics returns an EvalMetrics with its maps initialized.
+func newMetrics() *EvalMetrics {
+	return &EvalMetrics{
 		ByCategory: make(map[string]*CategoryMetrics),
 		ByTool:     make(map[string]*ToolMetrics),
 	}
+}
+
+// categoryMetric returns (creating if needed) the metrics bucket for a category.
+func (m *EvalMetrics) categoryMetric(name string) *CategoryMetrics {
+	if m.ByCategory[name] == nil {
+		m.ByCategory[name] = &CategoryMetrics{}
+	}
+	return m.ByCategory[name]
+}
+
+// toolMetric returns (creating if needed) the metrics bucket for a tool.
+func (m *EvalMetrics) toolMetric(name string) *ToolMetrics {
+	if m.ByTool[name] == nil {
+		m.ByTool[name] = &ToolMetrics{}
+	}
+	return m.ByTool[name]
+}
+
+// finalize computes the accuracy ratio once all tests have been recorded.
+func (m *EvalMetrics) finalize() {
+	if m.TotalTests > 0 {
+		m.Accuracy = float64(m.PassedTests) / float64(m.TotalTests)
+	}
+}
+
+// EvaluateToolSelection runs tool selection tests against a selector
+func EvaluateToolSelection(suite *ToolSelectionSuite, selector ToolSelector) (*EvalMetrics, []ToolSelectionResult) {
+	metrics := newMetrics()
 	var results []ToolSelectionResult
 
 	for _, test := range suite.Tests {
 		metrics.TotalTests++
+		metrics.categoryMetric(test.Category).Total++
+		metrics.toolMetric(test.ExpectedTool).ExpectedCount++
 
-		// Initialize category metrics
-		if metrics.ByCategory[test.Category] == nil {
-			metrics.ByCategory[test.Category] = &CategoryMetrics{}
-		}
-		metrics.ByCategory[test.Category].Total++
-
-		// Initialize tool metrics
-		if metrics.ByTool[test.ExpectedTool] == nil {
-			metrics.ByTool[test.ExpectedTool] = &ToolMetrics{}
-		}
-		metrics.ByTool[test.ExpectedTool].ExpectedCount++
-
-		// Run the selector
 		actualTool, actualArgs, err := selector.SelectTool(test.Input)
-
 		result := ToolSelectionResult{
 			TestID:       test.ID,
 			Input:        test.Input,
@@ -80,104 +96,95 @@ func EvaluateToolSelection(suite *ToolSelectionSuite, selector ToolSelector) (*E
 			ActualTool:   actualTool,
 			Passed:       true,
 		}
-
 		if err != nil {
 			result.Passed = false
 			result.Errors = append(result.Errors, fmt.Sprintf("selector error: %v", err))
 		}
 
-		// Check tool selection
-		if actualTool != test.ExpectedTool {
+		metrics.recordToolChoice(&test, actualTool, &result)
+		result.Errors = append(result.Errors, checkForbiddenTools(test.NotTools, actualTool)...)
+		result.Errors = append(result.Errors, checkExpectedArgs(test.ExpectedArgs, actualArgs)...)
+		if len(result.Errors) > 0 {
 			result.Passed = false
-			result.Errors = append(result.Errors,
-				fmt.Sprintf("wrong tool: expected %s, got %s", test.ExpectedTool, actualTool))
-			metrics.ByTool[test.ExpectedTool].FalseNegatives++
-
-			if metrics.ByTool[actualTool] == nil {
-				metrics.ByTool[actualTool] = &ToolMetrics{}
-			}
-			metrics.ByTool[actualTool].FalsePositives++
-		} else {
-			metrics.ByTool[test.ExpectedTool].CorrectCount++
 		}
 
-		// Track selected count
-		if metrics.ByTool[actualTool] == nil {
-			metrics.ByTool[actualTool] = &ToolMetrics{}
-		}
-		metrics.ByTool[actualTool].SelectedCount++
-
-		// Check forbidden tools
-		for _, forbidden := range test.NotTools {
-			if actualTool == forbidden {
-				result.Passed = false
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("selected forbidden tool: %s", forbidden))
-			}
-		}
-
-		// Check expected arguments
-		for key, expectedValue := range test.ExpectedArgs {
-			actualValue, exists := actualArgs[key]
-			if !exists {
-				result.Passed = false
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("missing arg %s (expected %v)", key, expectedValue))
-			} else if !compareValues(expectedValue, actualValue) {
-				result.Passed = false
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("wrong arg %s: expected %v, got %v", key, expectedValue, actualValue))
-			}
-		}
-
-		// Update metrics
-		if result.Passed {
-			metrics.PassedTests++
-			metrics.ByCategory[test.Category].Passed++
-		} else {
-			metrics.FailedTests++
-			metrics.ByCategory[test.Category].Failed++
-			metrics.FailedDetails = append(metrics.FailedDetails,
-				fmt.Sprintf("[%s] %s: %s", test.ID, test.Input, strings.Join(result.Errors, "; ")))
-		}
-
+		metrics.recordSelectionOutcome(&test, &result)
 		results = append(results, result)
 	}
 
-	if metrics.TotalTests > 0 {
-		metrics.Accuracy = float64(metrics.PassedTests) / float64(metrics.TotalTests)
-	}
-
+	metrics.finalize()
 	return metrics, results
+}
+
+// recordToolChoice updates per-tool counters for a selection and notes a
+// wrong-tool error on the result if the choice did not match.
+func (m *EvalMetrics) recordToolChoice(test *ToolSelectionTest, actualTool string, result *ToolSelectionResult) {
+	if actualTool != test.ExpectedTool {
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("wrong tool: expected %s, got %s", test.ExpectedTool, actualTool))
+		m.toolMetric(test.ExpectedTool).FalseNegatives++
+		m.toolMetric(actualTool).FalsePositives++
+	} else {
+		m.toolMetric(test.ExpectedTool).CorrectCount++
+	}
+	m.toolMetric(actualTool).SelectedCount++
+}
+
+// recordSelectionOutcome updates pass/fail aggregates for a tool-selection test.
+func (m *EvalMetrics) recordSelectionOutcome(test *ToolSelectionTest, result *ToolSelectionResult) {
+	cat := m.categoryMetric(test.Category)
+	if result.Passed {
+		m.PassedTests++
+		cat.Passed++
+		return
+	}
+	m.FailedTests++
+	cat.Failed++
+	m.FailedDetails = append(m.FailedDetails,
+		fmt.Sprintf("[%s] %s: %s", test.ID, test.Input, strings.Join(result.Errors, "; ")))
+}
+
+// checkForbiddenTools returns an error string for each forbidden tool that was
+// selected.
+func checkForbiddenTools(forbidden []string, actualTool string) []string {
+	var errs []string
+	for _, name := range forbidden {
+		if actualTool == name {
+			errs = append(errs, fmt.Sprintf("selected forbidden tool: %s", name))
+		}
+	}
+	return errs
+}
+
+// checkExpectedArgs returns an error string for each expected argument that is
+// missing or has the wrong value.
+func checkExpectedArgs(expected map[string]interface{}, actual map[string]interface{}) []string {
+	var errs []string
+	for key, expectedValue := range expected {
+		actualValue, exists := actual[key]
+		switch {
+		case !exists:
+			errs = append(errs, fmt.Sprintf("missing arg %s (expected %v)", key, expectedValue))
+		case !compareValues(expectedValue, actualValue):
+			errs = append(errs, fmt.Sprintf("wrong arg %s: expected %v, got %v", key, expectedValue, actualValue))
+		}
+	}
+	return errs
 }
 
 // EvaluateConfusionPairs runs confusion pair tests against a selector
 func EvaluateConfusionPairs(suite *ConfusionPairSuite, selector ToolSelector) (*EvalMetrics, []ConfusionPairResult) {
-	metrics := &EvalMetrics{
-		ByCategory: make(map[string]*CategoryMetrics),
-		ByTool:     make(map[string]*ToolMetrics),
-	}
+	metrics := newMetrics()
 	var results []ConfusionPairResult
 
 	for _, pair := range suite.Pairs {
-		// Use pair ID as category
-		if metrics.ByCategory[pair.ID] == nil {
-			metrics.ByCategory[pair.ID] = &CategoryMetrics{}
-		}
-
+		metrics.categoryMetric(pair.ID)
 		for _, test := range pair.Tests {
 			metrics.TotalTests++
-			metrics.ByCategory[pair.ID].Total++
+			metrics.categoryMetric(pair.ID).Total++
+			metrics.toolMetric(test.Expected).ExpectedCount++
 
-			// Initialize tool metrics
-			if metrics.ByTool[test.Expected] == nil {
-				metrics.ByTool[test.Expected] = &ToolMetrics{}
-			}
-			metrics.ByTool[test.Expected].ExpectedCount++
-
-			// Run the selector
 			actualTool, _, err := selector.SelectTool(test.Input)
-
 			result := ConfusionPairResult{
 				PairID:       pair.ID,
 				TestInput:    test.Input,
@@ -186,178 +193,193 @@ func EvaluateConfusionPairs(suite *ConfusionPairSuite, selector ToolSelector) (*
 				Reason:       test.Reason,
 				Passed:       err == nil && actualTool == test.Expected,
 			}
-
-			// Track metrics
-			if metrics.ByTool[actualTool] == nil {
-				metrics.ByTool[actualTool] = &ToolMetrics{}
-			}
-			metrics.ByTool[actualTool].SelectedCount++
-
-			if result.Passed {
-				metrics.PassedTests++
-				metrics.ByCategory[pair.ID].Passed++
-				metrics.ByTool[test.Expected].CorrectCount++
-			} else {
-				metrics.FailedTests++
-				metrics.ByCategory[pair.ID].Failed++
-				metrics.ByTool[test.Expected].FalseNegatives++
-				metrics.ByTool[actualTool].FalsePositives++
-				metrics.FailedDetails = append(metrics.FailedDetails,
-					fmt.Sprintf("[%s] %s: expected %s, got %s (%s)",
-						pair.ID, test.Input, test.Expected, actualTool, test.Reason))
-			}
-
+			metrics.toolMetric(actualTool).SelectedCount++
+			metrics.recordConfusionOutcome(pair.ID, &test, &result)
 			results = append(results, result)
 		}
 	}
 
-	if metrics.TotalTests > 0 {
-		metrics.Accuracy = float64(metrics.PassedTests) / float64(metrics.TotalTests)
-	}
-
+	metrics.finalize()
 	return metrics, results
+}
+
+// recordConfusionOutcome updates pass/fail aggregates for a confusion-pair test.
+func (m *EvalMetrics) recordConfusionOutcome(pairID string, test *ConfusionPairTest, result *ConfusionPairResult) {
+	cat := m.categoryMetric(pairID)
+	if result.Passed {
+		m.PassedTests++
+		cat.Passed++
+		m.toolMetric(test.Expected).CorrectCount++
+		return
+	}
+	m.FailedTests++
+	cat.Failed++
+	m.toolMetric(test.Expected).FalseNegatives++
+	m.toolMetric(result.ActualTool).FalsePositives++
+	m.FailedDetails = append(m.FailedDetails,
+		fmt.Sprintf("[%s] %s: expected %s, got %s (%s)",
+			pairID, test.Input, test.Expected, result.ActualTool, test.Reason))
 }
 
 // EvaluateArguments runs argument correctness tests against a selector
 func EvaluateArguments(suite *ArgumentSuite, selector ToolSelector) (*EvalMetrics, []ArgumentResult) {
-	metrics := &EvalMetrics{
-		ByCategory: make(map[string]*CategoryMetrics),
-		ByTool:     make(map[string]*ToolMetrics),
-	}
+	metrics := newMetrics()
 	var results []ArgumentResult
 
 	for _, test := range suite.Tests {
 		metrics.TotalTests++
+		metrics.categoryMetric(test.Tool).Total++
 
-		// Use tool name as category
-		if metrics.ByCategory[test.Tool] == nil {
-			metrics.ByCategory[test.Tool] = &CategoryMetrics{}
+		result, recorded := evaluateArgumentTest(&test, selector)
+		// Preserve original behavior: a selector error or wrong-tool
+		// short-circuit increments TotalTests/category Total only (above);
+		// it is neither tallied as pass/fail nor appended to results.
+		if recorded {
+			metrics.recordArgumentOutcome(&test, &result)
+			results = append(results, result)
 		}
-		metrics.ByCategory[test.Tool].Total++
-
-		// Run the selector
-		actualTool, actualArgs, err := selector.SelectTool(test.Input)
-
-		result := ArgumentResult{
-			TestID:    test.ID,
-			Tool:      test.Tool,
-			Input:     test.Input,
-			Passed:    true,
-			WrongArgs: make(map[string]string),
-		}
-
-		if err != nil {
-			result.Passed = false
-			continue
-		}
-
-		// Check correct tool was selected first
-		if actualTool != test.Tool {
-			result.Passed = false
-			continue
-		}
-
-		// Check required arguments
-		for _, reqArg := range test.RequiredArgs {
-			if _, exists := actualArgs[reqArg]; !exists {
-				result.Passed = false
-				result.MissingArgs = append(result.MissingArgs, reqArg)
-			}
-		}
-
-		// Check expected argument values
-		for key, expectedValue := range test.ExpectedArgs {
-			actualValue, exists := actualArgs[key]
-			if !exists {
-				result.Passed = false
-				result.MissingArgs = append(result.MissingArgs, key)
-			} else if !compareValues(expectedValue, actualValue) {
-				result.Passed = false
-				result.WrongArgs[key] = fmt.Sprintf("expected %v, got %v", expectedValue, actualValue)
-			}
-		}
-
-		// Check forbidden arguments
-		for _, forbidden := range test.ForbiddenArgs {
-			if _, exists := actualArgs[forbidden]; exists {
-				result.Passed = false
-				result.ForbiddenHit = append(result.ForbiddenHit, forbidden)
-			}
-		}
-
-		// Update metrics
-		if result.Passed {
-			metrics.PassedTests++
-			metrics.ByCategory[test.Tool].Passed++
-		} else {
-			metrics.FailedTests++
-			metrics.ByCategory[test.Tool].Failed++
-
-			var errDetails []string
-			if len(result.MissingArgs) > 0 {
-				errDetails = append(errDetails, fmt.Sprintf("missing: %v", result.MissingArgs))
-			}
-			for k, v := range result.WrongArgs {
-				errDetails = append(errDetails, fmt.Sprintf("%s: %s", k, v))
-			}
-			if len(result.ForbiddenHit) > 0 {
-				errDetails = append(errDetails, fmt.Sprintf("forbidden: %v", result.ForbiddenHit))
-			}
-			metrics.FailedDetails = append(metrics.FailedDetails,
-				fmt.Sprintf("[%s] %s: %s", test.ID, test.Input, strings.Join(errDetails, "; ")))
-		}
-
-		results = append(results, result)
 	}
 
-	if metrics.TotalTests > 0 {
-		metrics.Accuracy = float64(metrics.PassedTests) / float64(metrics.TotalTests)
-	}
-
+	metrics.finalize()
 	return metrics, results
+}
+
+// evaluateArgumentTest runs a single argument-correctness test and returns its
+// result. The recorded flag is false when the test short-circuited on a
+// selector error or wrong tool, in which case the caller omits it from the
+// detailed results slice (matching the original control flow).
+func evaluateArgumentTest(test *ArgumentTest, selector ToolSelector) (result ArgumentResult, recorded bool) {
+	result = ArgumentResult{
+		TestID:    test.ID,
+		Tool:      test.Tool,
+		Input:     test.Input,
+		Passed:    true,
+		WrongArgs: make(map[string]string),
+	}
+
+	actualTool, actualArgs, err := selector.SelectTool(test.Input)
+	if err != nil || actualTool != test.Tool {
+		result.Passed = false
+		return result, false
+	}
+
+	checkRequiredArgs(test.RequiredArgs, actualArgs, &result)
+	checkExpectedArgValues(test.ExpectedArgs, actualArgs, &result)
+	checkForbiddenArgs(test.ForbiddenArgs, actualArgs, &result)
+	return result, true
+}
+
+// checkRequiredArgs marks missing required arguments on the result.
+func checkRequiredArgs(required []string, actual map[string]interface{}, result *ArgumentResult) {
+	for _, reqArg := range required {
+		if _, exists := actual[reqArg]; !exists {
+			result.Passed = false
+			result.MissingArgs = append(result.MissingArgs, reqArg)
+		}
+	}
+}
+
+// checkExpectedArgValues marks missing or wrong-valued expected arguments.
+func checkExpectedArgValues(expected map[string]interface{}, actual map[string]interface{}, result *ArgumentResult) {
+	for key, expectedValue := range expected {
+		actualValue, exists := actual[key]
+		switch {
+		case !exists:
+			result.Passed = false
+			result.MissingArgs = append(result.MissingArgs, key)
+		case !compareValues(expectedValue, actualValue):
+			result.Passed = false
+			result.WrongArgs[key] = fmt.Sprintf("expected %v, got %v", expectedValue, actualValue)
+		}
+	}
+}
+
+// checkForbiddenArgs marks any forbidden argument that was supplied.
+func checkForbiddenArgs(forbidden []string, actual map[string]interface{}, result *ArgumentResult) {
+	for _, name := range forbidden {
+		if _, exists := actual[name]; exists {
+			result.Passed = false
+			result.ForbiddenHit = append(result.ForbiddenHit, name)
+		}
+	}
+}
+
+// recordArgumentOutcome updates pass/fail aggregates for an argument test.
+func (m *EvalMetrics) recordArgumentOutcome(test *ArgumentTest, result *ArgumentResult) {
+	cat := m.categoryMetric(test.Tool)
+	if result.Passed {
+		m.PassedTests++
+		cat.Passed++
+		return
+	}
+	m.FailedTests++
+	cat.Failed++
+	m.FailedDetails = append(m.FailedDetails,
+		fmt.Sprintf("[%s] %s: %s", test.ID, test.Input, formatArgErrors(result)))
+}
+
+// formatArgErrors renders the missing/wrong/forbidden detail for a failed
+// argument test into a single semicolon-joined string.
+func formatArgErrors(result *ArgumentResult) string {
+	var errDetails []string
+	if len(result.MissingArgs) > 0 {
+		errDetails = append(errDetails, fmt.Sprintf("missing: %v", result.MissingArgs))
+	}
+	for k, v := range result.WrongArgs {
+		errDetails = append(errDetails, fmt.Sprintf("%s: %s", k, v))
+	}
+	if len(result.ForbiddenHit) > 0 {
+		errDetails = append(errDetails, fmt.Sprintf("forbidden: %v", result.ForbiddenHit))
+	}
+	return strings.Join(errDetails, "; ")
 }
 
 // compareValues compares expected and actual values, handling type differences
 func compareValues(expected, actual interface{}) bool {
-	// Handle nil cases
-	if expected == nil && actual == nil {
-		return true
-	}
 	if expected == nil || actual == nil {
-		return false
+		return expected == nil && actual == nil
 	}
 
-	// Use reflect for deep comparison
 	ev := reflect.ValueOf(expected)
 	av := reflect.ValueOf(actual)
 
-	// Handle numeric type differences (JSON unmarshals to float64)
+	if matched, equal := compareNumeric(ev, av); matched {
+		return equal
+	}
+	if ev.Kind() == reflect.Slice && av.Kind() == reflect.Slice {
+		return compareSlices(ev, av)
+	}
+	return reflect.DeepEqual(expected, actual)
+}
+
+// compareNumeric handles the JSON-unmarshals-numbers-to-float64 case. It
+// returns matched=true when expected is a numeric kind, along with whether the
+// two values are equal.
+func compareNumeric(ev, av reflect.Value) (matched, equal bool) {
+	if av.Kind() != reflect.Float64 {
+		return false, false
+	}
 	switch ev.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		if av.Kind() == reflect.Float64 {
-			return float64(ev.Int()) == av.Float()
-		}
+		return true, float64(ev.Int()) == av.Float()
 	case reflect.Float32, reflect.Float64:
-		if av.Kind() == reflect.Float64 {
-			return ev.Float() == av.Float()
-		}
+		return true, ev.Float() == av.Float()
+	default:
+		return false, false
 	}
+}
 
-	// Handle slice comparison
-	if ev.Kind() == reflect.Slice && av.Kind() == reflect.Slice {
-		if ev.Len() != av.Len() {
+// compareSlices compares two slices element-by-element via compareValues.
+func compareSlices(ev, av reflect.Value) bool {
+	if ev.Len() != av.Len() {
+		return false
+	}
+	for i := 0; i < ev.Len(); i++ {
+		if !compareValues(ev.Index(i).Interface(), av.Index(i).Interface()) {
 			return false
 		}
-		for i := 0; i < ev.Len(); i++ {
-			if !compareValues(ev.Index(i).Interface(), av.Index(i).Interface()) {
-				return false
-			}
-		}
-		return true
 	}
-
-	// Default: use reflect.DeepEqual
-	return reflect.DeepEqual(expected, actual)
+	return true
 }
 
 // FormatMetrics returns a human-readable summary of evaluation metrics
@@ -369,29 +391,41 @@ func FormatMetrics(metrics *EvalMetrics, suiteName string) string {
 	b.WriteString(fmt.Sprintf("Passed: %d (%.1f%%)\n", metrics.PassedTests, metrics.Accuracy*100))
 	b.WriteString(fmt.Sprintf("Failed: %d\n", metrics.FailedTests))
 
-	if len(metrics.ByCategory) > 0 {
-		b.WriteString("\nBy Category:\n")
-		for cat, m := range metrics.ByCategory {
-			if m.Total > 0 {
-				acc := float64(m.Passed) / float64(m.Total) * 100
-				b.WriteString(fmt.Sprintf("  %-25s: %d/%d (%.0f%%)\n", cat, m.Passed, m.Total, acc))
-			}
-		}
-	}
-
-	if len(metrics.FailedDetails) > 0 && len(metrics.FailedDetails) <= 10 {
-		b.WriteString("\nFailed Tests:\n")
-		for _, detail := range metrics.FailedDetails {
-			b.WriteString(fmt.Sprintf("  - %s\n", detail))
-		}
-	} else if len(metrics.FailedDetails) > 10 {
-		b.WriteString(fmt.Sprintf("\nFailed Tests (showing first 10 of %d):\n", len(metrics.FailedDetails)))
-		for _, detail := range metrics.FailedDetails[:10] {
-			b.WriteString(fmt.Sprintf("  - %s\n", detail))
-		}
-	}
+	writeCategoryBreakdown(&b, metrics.ByCategory)
+	writeFailedDetails(&b, metrics.FailedDetails)
 
 	return b.String()
+}
+
+// writeCategoryBreakdown appends a per-category accuracy table to b.
+func writeCategoryBreakdown(b *strings.Builder, byCategory map[string]*CategoryMetrics) {
+	if len(byCategory) == 0 {
+		return
+	}
+	b.WriteString("\nBy Category:\n")
+	for cat, m := range byCategory {
+		if m.Total > 0 {
+			acc := float64(m.Passed) / float64(m.Total) * 100
+			b.WriteString(fmt.Sprintf("  %-25s: %d/%d (%.0f%%)\n", cat, m.Passed, m.Total, acc))
+		}
+	}
+}
+
+// writeFailedDetails appends the failed-test list to b, capped at 10 entries.
+func writeFailedDetails(b *strings.Builder, details []string) {
+	if len(details) == 0 {
+		return
+	}
+	shown := details
+	if len(details) > 10 {
+		b.WriteString(fmt.Sprintf("\nFailed Tests (showing first 10 of %d):\n", len(details)))
+		shown = details[:10]
+	} else {
+		b.WriteString("\nFailed Tests:\n")
+	}
+	for _, detail := range shown {
+		b.WriteString(fmt.Sprintf("  - %s\n", detail))
+	}
 }
 
 // LoadAllEvals loads all evaluation suites from a directory

--- a/main.go
+++ b/main.go
@@ -318,7 +318,11 @@ func registerToolsAndResources(server *mcp.Server, client *wiki.Client, logger *
 			logger.Warn("Failed to create tool audit logger", "path", auditLogPath, "error", err)
 		} else {
 			registry.WithAuditLogger(toolAuditLogger)
-			cleanup = func() { toolAuditLogger.Close() }
+			cleanup = func() {
+				if err := toolAuditLogger.Close(); err != nil {
+					logger.Warn("Failed to close tool audit logger", "error", err)
+				}
+			}
 			logger.Info("Tool audit logging enabled", "path", auditLogPath)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -320,7 +320,18 @@ Read operations work without authentication.`,
 	// Choose transport based on flags
 	if *httpAddr != "" {
 		// HTTP transport mode (for ChatGPT, n8n, and remote clients)
-		runHTTPServer(server, logger, *httpAddr, authToken, *allowedOrigins, *rateLimit, *trustedProxies, config.BaseURL, client, serverCard)
+		runHTTPServer(httpServerConfig{
+			Server:         server,
+			Logger:         logger,
+			Addr:           *httpAddr,
+			AuthToken:      authToken,
+			Origins:        *allowedOrigins,
+			RateLimit:      *rateLimit,
+			TrustedProxies: *trustedProxies,
+			WikiURL:        config.BaseURL,
+			Client:         client,
+			Card:           serverCard,
+		})
 	} else {
 		// stdio transport mode (default, for Claude Desktop, Cursor, etc.)
 		logger.Info("Starting MediaWiki MCP Server (stdio mode)",

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"runtime/debug"
 	"syscall"
-	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/olgasafonova/mcp-servercard-go/servercard"
@@ -36,120 +35,9 @@ const (
 	ServerVersion = "1.28.1"
 )
 
-// =============================================================================
-// Markdown Converter Types (not a wiki.Client method)
-// =============================================================================
-
-// ConvertMarkdownArgs holds parameters for the mediawiki_convert_markdown tool
-type ConvertMarkdownArgs struct {
-	// Markdown is the source text to convert (required)
-	Markdown string `json:"markdown" jsonschema:"The Markdown text to convert to MediaWiki markup"`
-
-	// Theme selects the color scheme: "tieto", "neutral" (default), or "dark"
-	Theme string `json:"theme,omitempty" jsonschema:"Color theme: 'tieto' (brand colors), 'neutral' (no styling, default), or 'dark' (dark mode)"`
-
-	// AddCSS includes CSS styling block in output for branded appearance
-	AddCSS *bool `json:"add_css,omitempty" jsonschema:"Include CSS styling block for branded appearance"`
-
-	// ReverseChangelog reorders changelog entries newest-first
-	ReverseChangelog *bool `json:"reverse_changelog,omitempty" jsonschema:"Reorder changelog entries with newest first"`
-
-	// PrettifyChecks replaces plain checkmarks (✓) with emoji (✅)
-	PrettifyChecks *bool `json:"prettify_checks,omitempty" jsonschema:"Replace plain checkmarks with emoji ✅"`
-}
-
-// ConvertMarkdownResult contains the conversion output
-type ConvertMarkdownResult struct {
-	// Wikitext is the converted MediaWiki markup
-	Wikitext string `json:"wikitext"`
-
-	// InputLength is the character count of input Markdown
-	InputLength int `json:"input_length"`
-
-	// OutputLength is the character count of output wikitext
-	OutputLength int `json:"output_length"`
-
-	// ThemeUsed indicates which theme was applied
-	ThemeUsed string `json:"theme_used"`
-
-	// AvailableThemes lists all supported themes
-	AvailableThemes []converter.ThemeInfo `json:"available_themes"`
-}
-
-// =============================================================================
-// Security Middleware for HTTP Transport
-// =============================================================================
-
-func main() {
-	// Parse command-line flags
-	httpAddr := flag.String("http", "", "HTTP address to listen on (e.g., :8080 or 127.0.0.1:8080). If empty, uses stdio transport.")
-	bearerToken := flag.String("token", "", "Bearer token for HTTP authentication. Can also use MCP_AUTH_TOKEN env var.")
-	allowedOrigins := flag.String("origins", "", "Comma-separated allowed origins for CORS (e.g., 'https://chat.openai.com,https://n8n.example.com'). Empty allows all.")
-	rateLimit := flag.Int("rate-limit", 60, "Maximum requests per minute per IP (0 = unlimited)")
-	trustedProxies := flag.String("trusted-proxies", "", "Comma-separated trusted proxy IPs/CIDRs (e.g., '10.0.0.0/8,192.168.1.1'). Required to trust X-Forwarded-For header.")
-	flag.Parse()
-
-	// Configure logging to stderr (stdout is used for MCP protocol in stdio mode)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
-
-	// Initialize OpenTelemetry tracing
-	tracingConfig := tracing.DefaultConfig()
-	tracingConfig.ServiceVersion = ServerVersion
-	shutdownTracing, err := tracing.Setup(context.Background(), tracingConfig)
-	if err != nil {
-		logger.Warn("Failed to initialize tracing", "error", err)
-	} else if tracingConfig.Enabled {
-		defer func() { _ = shutdownTracing(context.Background()) }()
-		logger.Info("OpenTelemetry tracing enabled",
-			"endpoint", tracingConfig.OTLPEndpoint,
-			"service", tracingConfig.ServiceName)
-	}
-
-	// Load configuration from environment.
-	// Uses LoadConfigOrUnconfigured so the server starts even without MEDIAWIKI_URL,
-	// allowing MCP registries (Glama, Smithery) to inspect tool definitions.
-	// Tool calls will return a clear error if the wiki URL is not configured.
-	config, err := wiki.LoadConfigOrUnconfigured()
-	if err != nil {
-		log.Fatalf("Failed to load configuration: %v", err)
-	}
-	if !config.IsConfigured() {
-		logger.Warn("MEDIAWIKI_URL not set. Server will start in inspection mode: tools are listed but calls will fail until configured.")
-	}
-
-	// Create MediaWiki client
-	client := wiki.NewClient(config, logger)
-
-	// Configure audit logging if MEDIAWIKI_AUDIT_LOG is set
-	if auditLogPath := os.Getenv("MEDIAWIKI_AUDIT_LOG"); auditLogPath != "" {
-		auditLogger, err := wiki.NewFileAuditLogger(auditLogPath, logger)
-		if err != nil {
-			logger.Warn("Failed to create audit logger", "path", auditLogPath, "error", err)
-		} else {
-			client.SetAuditLogger(auditLogger)
-			logger.Info("Audit logging enabled", "path", auditLogPath)
-		}
-	}
-
-	// Get bearer token from flag or environment
-	authToken := *bearerToken
-	if authToken == "" {
-		authToken = os.Getenv("MCP_AUTH_TOKEN")
-	}
-
-	// Create MCP server
-	server := mcp.NewServer(&mcp.Implementation{
-		Name:    ServerName,
-		Version: ServerVersion,
-	}, &mcp.ServerOptions{
-		Logger: logger,
-		// Suppress pre-initialize notifications/tools/list_changed from go-sdk.
-		// Without this, AddTool triggers a notification before the client completes
-		// the initialize handshake, causing intermittent connection failures.
-		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
-		Instructions: `MediaWiki MCP Server - Tool Selection Guide
+// serverInstructions is the tool-selection guide handed to MCP clients on
+// connect. Kept as a top-level constant so main() stays small.
+const serverInstructions = `MediaWiki MCP Server - Tool Selection Guide
 
 ` + WikiEditingGuidelines + `
 
@@ -268,33 +156,181 @@ X DON'T fetch entire page just to search within it
 ## AUTHENTICATION
 
 Editing requires MEDIAWIKI_USERNAME and MEDIAWIKI_PASSWORD environment variables.
-Read operations work without authentication.`,
+Read operations work without authentication.`
+
+// =============================================================================
+// Markdown Converter Types (not a wiki.Client method)
+// =============================================================================
+
+// ConvertMarkdownArgs holds parameters for the mediawiki_convert_markdown tool
+type ConvertMarkdownArgs struct {
+	// Markdown is the source text to convert (required)
+	Markdown string `json:"markdown" jsonschema:"The Markdown text to convert to MediaWiki markup"`
+
+	// Theme selects the color scheme: "tieto", "neutral" (default), or "dark"
+	Theme string `json:"theme,omitempty" jsonschema:"Color theme: 'tieto' (brand colors), 'neutral' (no styling, default), or 'dark' (dark mode)"`
+
+	// AddCSS includes CSS styling block in output for branded appearance
+	AddCSS *bool `json:"add_css,omitempty" jsonschema:"Include CSS styling block for branded appearance"`
+
+	// ReverseChangelog reorders changelog entries newest-first
+	ReverseChangelog *bool `json:"reverse_changelog,omitempty" jsonschema:"Reorder changelog entries with newest first"`
+
+	// PrettifyChecks replaces plain checkmarks (✓) with emoji (✅)
+	PrettifyChecks *bool `json:"prettify_checks,omitempty" jsonschema:"Replace plain checkmarks with emoji ✅"`
+}
+
+// ConvertMarkdownResult contains the conversion output
+type ConvertMarkdownResult struct {
+	// Wikitext is the converted MediaWiki markup
+	Wikitext string `json:"wikitext"`
+
+	// InputLength is the character count of input Markdown
+	InputLength int `json:"input_length"`
+
+	// OutputLength is the character count of output wikitext
+	OutputLength int `json:"output_length"`
+
+	// ThemeUsed indicates which theme was applied
+	ThemeUsed string `json:"theme_used"`
+
+	// AvailableThemes lists all supported themes
+	AvailableThemes []converter.ThemeInfo `json:"available_themes"`
+}
+
+// =============================================================================
+// Security Middleware for HTTP Transport
+// =============================================================================
+
+// cliFlags holds the parsed command-line flags.
+type cliFlags struct {
+	httpAddr       string
+	bearerToken    string
+	allowedOrigins string
+	rateLimit      int
+	trustedProxies string
+}
+
+// parseFlags parses the command-line flags into a cliFlags value.
+func parseFlags() cliFlags {
+	httpAddr := flag.String("http", "", "HTTP address to listen on (e.g., :8080 or 127.0.0.1:8080). If empty, uses stdio transport.")
+	bearerToken := flag.String("token", "", "Bearer token for HTTP authentication. Can also use MCP_AUTH_TOKEN env var.")
+	allowedOrigins := flag.String("origins", "", "Comma-separated allowed origins for CORS (e.g., 'https://chat.openai.com,https://n8n.example.com'). Empty allows all.")
+	rateLimit := flag.Int("rate-limit", 60, "Maximum requests per minute per IP (0 = unlimited)")
+	trustedProxies := flag.String("trusted-proxies", "", "Comma-separated trusted proxy IPs/CIDRs (e.g., '10.0.0.0/8,192.168.1.1'). Required to trust X-Forwarded-For header.")
+	flag.Parse()
+	return cliFlags{
+		httpAddr:       *httpAddr,
+		bearerToken:    *bearerToken,
+		allowedOrigins: *allowedOrigins,
+		rateLimit:      *rateLimit,
+		trustedProxies: *trustedProxies,
+	}
+}
+
+// newLogger configures logging to stderr (stdout is reserved for the MCP
+// protocol in stdio mode).
+func newLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+}
+
+// setupTracing initializes OpenTelemetry tracing and returns a shutdown
+// function (no-op when tracing is disabled).
+func setupTracing(logger *slog.Logger) func() {
+	tracingConfig := tracing.DefaultConfig()
+	tracingConfig.ServiceVersion = ServerVersion
+	shutdownTracing, err := tracing.Setup(context.Background(), tracingConfig)
+	if err != nil {
+		logger.Warn("Failed to initialize tracing", "error", err)
+		return func() {}
+	}
+	if !tracingConfig.Enabled {
+		return func() {}
+	}
+	logger.Info("OpenTelemetry tracing enabled",
+		"endpoint", tracingConfig.OTLPEndpoint,
+		"service", tracingConfig.ServiceName)
+	return func() { _ = shutdownTracing(context.Background()) }
+}
+
+// loadConfigAndClient loads configuration, builds the wiki client, and wires up
+// client-level audit logging when configured.
+func loadConfigAndClient(logger *slog.Logger) (*wiki.Config, *wiki.Client) {
+	// Uses LoadConfigOrUnconfigured so the server starts even without
+	// MEDIAWIKI_URL, allowing MCP registries (Glama, Smithery) to inspect tool
+	// definitions. Tool calls return a clear error if the wiki URL is unset.
+	config, err := wiki.LoadConfigOrUnconfigured()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+	if !config.IsConfigured() {
+		logger.Warn("MEDIAWIKI_URL not set. Server will start in inspection mode: tools are listed but calls will fail until configured.")
+	}
+
+	client := wiki.NewClient(config, logger)
+	if auditLogPath := os.Getenv("MEDIAWIKI_AUDIT_LOG"); auditLogPath != "" {
+		auditLogger, err := wiki.NewFileAuditLogger(auditLogPath, logger)
+		if err != nil {
+			logger.Warn("Failed to create audit logger", "path", auditLogPath, "error", err)
+		} else {
+			client.SetAuditLogger(auditLogger)
+			logger.Info("Audit logging enabled", "path", auditLogPath)
+		}
+	}
+	return config, client
+}
+
+// resolveAuthToken prefers the -token flag, falling back to MCP_AUTH_TOKEN.
+func resolveAuthToken(flagToken string) string {
+	if flagToken != "" {
+		return flagToken
+	}
+	return os.Getenv("MCP_AUTH_TOKEN")
+}
+
+// newMCPServer constructs the MCP server with the tool-selection instructions.
+func newMCPServer(logger *slog.Logger) *mcp.Server {
+	return mcp.NewServer(&mcp.Implementation{
+		Name:    ServerName,
+		Version: ServerVersion,
+	}, &mcp.ServerOptions{
+		Logger: logger,
+		// Suppress pre-initialize notifications/tools/list_changed from go-sdk.
+		// Without this, AddTool triggers a notification before the client
+		// completes the initialize handshake, causing intermittent failures.
+		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
+		Instructions: serverInstructions,
 	})
+}
 
-	// Register all wiki tools using the registry
+// registerToolsAndResources registers all wiki tools, the converter tool, and
+// the wiki resources. It returns a cleanup function for any audit logger.
+func registerToolsAndResources(server *mcp.Server, client *wiki.Client, logger *slog.Logger) func() {
 	registry := tools.NewHandlerRegistry(client, logger)
+	cleanup := func() {}
 
-	// Configure handler-level audit logging (covers all tool calls, not just writes)
+	// Handler-level audit logging covers all tool calls, not just writes.
 	if auditLogPath := os.Getenv("MEDIAWIKI_AUDIT_LOG"); auditLogPath != "" {
 		toolAuditLogger, err := tools.NewFileToolAuditLogger(auditLogPath, logger)
 		if err != nil {
 			logger.Warn("Failed to create tool audit logger", "path", auditLogPath, "error", err)
 		} else {
 			registry.WithAuditLogger(toolAuditLogger)
-			defer toolAuditLogger.Close()
+			cleanup = func() { toolAuditLogger.Close() }
 			logger.Info("Tool audit logging enabled", "path", auditLogPath)
 		}
 	}
 
 	registry.RegisterAll(server)
-
-	// Register the Markdown converter tool (not a wiki.Client method)
 	registerConverterTool(server, logger)
-
-	// Register resources for direct wiki page access
 	registerResources(server, client, logger)
+	return cleanup
+}
 
-	// Build SEP-2127 Server Card for HTTP discovery
+// buildServerCard builds the SEP-2127 Server Card for HTTP discovery.
+func buildServerCard() *servercard.ServerCard {
 	cardOpts := servercard.Options{
 		Name:        "io.github.olgasafonova/mediawiki-mcp-server",
 		Version:     ServerVersion,
@@ -314,69 +350,74 @@ Read operations work without authentication.`,
 	if err != nil {
 		log.Fatalf("Server card error: %v", err)
 	}
+	return serverCard
+}
 
-	ctx := context.Background()
+// runStdioServer runs the server over stdio with graceful shutdown handling.
+func runStdioServer(server *mcp.Server, client *wiki.Client, config *wiki.Config, logger *slog.Logger) {
+	logger.Info("Starting MediaWiki MCP Server (stdio mode)",
+		"name", ServerName,
+		"version", ServerVersion,
+		"wiki_url", config.BaseURL,
+	)
 
-	// Choose transport based on flags
-	if *httpAddr != "" {
+	if config.IsConfigured() {
+		warmCacheAsync(client, logger)
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		sig := <-sigChan
+		logger.Info("Shutdown signal received", "signal", sig.String())
+		cancel()
+	}()
+
+	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil && err != context.Canceled {
+		log.Fatalf("Server error: %v", err)
+	}
+
+	client.Close()
+	logger.Info("Shutdown complete")
+}
+
+func main() {
+	flags := parseFlags()
+	logger := newLogger()
+
+	shutdownTracing := setupTracing(logger)
+	defer shutdownTracing()
+
+	config, client := loadConfigAndClient(logger)
+	authToken := resolveAuthToken(flags.bearerToken)
+
+	server := newMCPServer(logger)
+	cleanupAudit := registerToolsAndResources(server, client, logger)
+	defer cleanupAudit()
+
+	serverCard := buildServerCard()
+
+	if flags.httpAddr != "" {
 		// HTTP transport mode (for ChatGPT, n8n, and remote clients)
 		runHTTPServer(httpServerConfig{
 			Server:         server,
 			Logger:         logger,
-			Addr:           *httpAddr,
+			Addr:           flags.httpAddr,
 			AuthToken:      authToken,
-			Origins:        *allowedOrigins,
-			RateLimit:      *rateLimit,
-			TrustedProxies: *trustedProxies,
+			Origins:        flags.allowedOrigins,
+			RateLimit:      flags.rateLimit,
+			TrustedProxies: flags.trustedProxies,
 			WikiURL:        config.BaseURL,
 			Client:         client,
 			Card:           serverCard,
 		})
-	} else {
-		// stdio transport mode (default, for Claude Desktop, Cursor, etc.)
-		logger.Info("Starting MediaWiki MCP Server (stdio mode)",
-			"name", ServerName,
-			"version", ServerVersion,
-			"wiki_url", config.BaseURL,
-		)
-
-		// Warm cache in background (don't block startup); skip if unconfigured
-		if config.IsConfigured() {
-			go func() {
-				warmCtx, warmCancel := context.WithTimeout(context.Background(), 30*time.Second)
-				defer warmCancel()
-				if err := client.WarmCacheWithDefaults(warmCtx); err != nil {
-					logger.Warn("Cache warming failed", "error", err)
-				} else {
-					logger.Info("Cache warming completed")
-				}
-			}()
-		}
-
-		// Set up signal handling for graceful shutdown in stdio mode
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-		// Create a cancellable context for the server
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		// Handle shutdown signal in background
-		go func() {
-			sig := <-sigChan
-			logger.Info("Shutdown signal received", "signal", sig.String())
-			cancel()
-		}()
-
-		// Run the server
-		if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil && err != context.Canceled {
-			log.Fatalf("Server error: %v", err)
-		}
-
-		// Clean up resources
-		client.Close()
-		logger.Info("Shutdown complete")
+		return
 	}
+
+	runStdioServer(server, client, config, logger)
 }
 
 func ptr[T any](v T) *T {

--- a/main_httpserver.go
+++ b/main_httpserver.go
@@ -23,70 +23,117 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// httpServerConfig groups the configuration needed to run the HTTP transport.
+// Grouping these into one struct keeps runHTTPServer's signature small.
+type httpServerConfig struct {
+	Server         *mcp.Server
+	Logger         *slog.Logger
+	Addr           string
+	AuthToken      string
+	Origins        string
+	RateLimit      int
+	TrustedProxies string
+	WikiURL        string
+	Client         *wiki.Client
+	Card           *servercard.ServerCard
+}
+
+// splitCSV parses a comma-separated value into a trimmed, non-empty list.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, item := range strings.Split(s, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
 // runHTTPServer starts the MCP server with HTTP transport and graceful shutdown
-func runHTTPServer(server *mcp.Server, logger *slog.Logger, addr, authToken, origins string, rateLimit int, trustedProxies, wikiURL string, client *wiki.Client, card *servercard.ServerCard) {
-	// Parse allowed origins
-	var allowedOriginsList []string
-	if origins != "" {
-		for _, o := range strings.Split(origins, ",") {
-			o = strings.TrimSpace(o)
-			if o != "" {
-				allowedOriginsList = append(allowedOriginsList, o)
-			}
-		}
+func runHTTPServer(cfg httpServerConfig) {
+	allowedOriginsList := splitCSV(cfg.Origins)
+
+	securedHandler := newSecuredMCPHandler(cfg, allowedOriginsList)
+	mux := buildHTTPMux(cfg, securedHandler)
+	httpServer := &http.Server{
+		Addr:         cfg.Addr,
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
-	// Parse trusted proxies
-	var trustedProxiesList []string
-	if trustedProxies != "" {
-		for _, p := range strings.Split(trustedProxies, ",") {
-			p = strings.TrimSpace(p)
-			if p != "" {
-				trustedProxiesList = append(trustedProxiesList, p)
-			}
-		}
-	}
+	logStartup(cfg, allowedOriginsList)
+	warmCacheAsync(cfg.Client, cfg.Logger)
+	logSecurityWarnings(cfg.Logger, cfg.AuthToken, cfg.Addr)
 
-	// Create the Streamable HTTP handler
+	serveUntilSignal(httpServer, cfg.Logger)
+	shutdownServer(httpServer, securedHandler, cfg.Client, cfg.Logger)
+}
+
+// newSecuredMCPHandler builds the Streamable HTTP MCP handler wrapped in the
+// security middleware.
+func newSecuredMCPHandler(cfg httpServerConfig, allowedOrigins []string) *SecurityMiddleware {
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
-		return server
+		return cfg.Server
 	}, nil)
 
-	// Wrap with security middleware
 	securityConfig := SecurityConfig{
-		BearerToken:    authToken,
-		AllowedOrigins: allowedOriginsList,
-		RateLimit:      rateLimit,
-		TrustedProxies: trustedProxiesList,
+		BearerToken:    cfg.AuthToken,
+		AllowedOrigins: allowedOrigins,
+		RateLimit:      cfg.RateLimit,
+		TrustedProxies: splitCSV(cfg.TrustedProxies),
 	}
-	securedHandler := NewSecurityMiddleware(mcpHandler, logger, securityConfig)
+	return NewSecurityMiddleware(mcpHandler, cfg.Logger, securityConfig)
+}
 
-	// Create mux for routing health checks separately from MCP
+// buildHTTPMux wires the health, readiness, metrics, server-card, tools, status,
+// and MCP routes onto a fresh mux.
+func buildHTTPMux(cfg httpServerConfig, securedHandler http.Handler) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	// Health endpoint (no auth required - for load balancers and monitoring)
-	// This is a simple liveness check that doesn't verify wiki connectivity
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/ready", handleReady(cfg.WikiURL, cfg.Client))
+	mux.Handle("/metrics", promhttp.Handler())
+
+	cfg.Card.Remotes = []servercard.Remote{{
+		Type:                      "streamable-http",
+		URL:                       "/",
+		SupportedProtocolVersions: []string{"2025-06-18"},
+	}}
+	mux.Handle(servercard.WellKnownPath, servercard.Handler(cfg.Card))
+
+	mux.HandleFunc("/tools", handleTools(cfg.Logger))
+	mux.HandleFunc("/status", handleStatus(cfg.Client, cfg.Logger))
+	mux.Handle("/", securedHandler)
+	return mux
+}
+
+// handleHealth is a simple liveness check that does not verify wiki connectivity
+// (no auth required - for load balancers and monitoring).
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, `{"status":"healthy","server":"%s","version":"%s"}`, ServerName, ServerVersion)
+}
+
+// handleReady returns a readiness handler that verifies actual wiki
+// connectivity with a short timeout.
+func handleReady(wikiURL string, client *wiki.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "no-store")
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, `{"status":"healthy","server":"%s","version":"%s"}`, ServerName, ServerVersion)
-	})
 
-	// Readiness endpoint - verifies actual wiki connectivity
-	// Use short timeout to avoid blocking health checks
-	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Cache-Control", "no-store")
-
-		// Check if wiki URL is configured
 		if wikiURL == "" {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = fmt.Fprintf(w, `{"status":"not_ready","error":"wiki_url_not_configured"}`)
 			return
 		}
 
-		// Check actual wiki connectivity with timeout
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
 
@@ -101,25 +148,16 @@ func runHTTPServer(server *mcp.Server, logger *slog.Logger, addr, authToken, ori
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprintf(w, `{"status":"ready","wiki_url":"%s","site_name":"%s","generator":"%s","authenticated":%t,"response_time_ms":%d}`, // #nosec G705 -- health endpoint returns server config, not user input
 			health.WikiURL, health.SiteName, health.Generator, health.Authenticated, health.ResponseTime.Milliseconds())
-	})
+	}
+}
 
-	// Prometheus metrics endpoint (no auth required - for monitoring systems)
-	mux.Handle("/metrics", promhttp.Handler())
-
-	// SEP-2127 Server Card endpoint (no auth required - for pre-connect discovery)
-	card.Remotes = []servercard.Remote{{
-		Type:                      "streamable-http",
-		URL:                       "/",
-		SupportedProtocolVersions: []string{"2025-06-18"},
-	}}
-	mux.Handle(servercard.WellKnownPath, servercard.Handler(card))
-
-	// Tools discovery endpoint (no auth required - for tool introspection)
-	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+// handleTools returns a handler that lists available tools grouped by category
+// (no auth required - for tool introspection).
+func handleTools(logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=3600") // Cache for 1 hour
 
-		// Group tools by category
 		toolsByCategory := make(map[string][]map[string]interface{})
 		for _, tool := range tools.AllTools {
 			toolInfo := map[string]interface{}{
@@ -139,14 +177,16 @@ func runHTTPServer(server *mcp.Server, logger *slog.Logger, addr, authToken, ori
 			"tool_count": len(tools.AllTools),
 			"categories": toolsByCategory,
 		}
-
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			logger.Error("Failed to encode tools response", "error", err)
 		}
-	})
+	}
+}
 
-	// Circuit breaker status endpoint (no auth - for monitoring)
-	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+// handleStatus returns a handler exposing circuit-breaker and dedup status
+// (no auth - for monitoring).
+func handleStatus(client *wiki.Client, logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "no-store")
 
@@ -165,36 +205,28 @@ func runHTTPServer(server *mcp.Server, logger *slog.Logger, addr, authToken, ori
 				"inflight_requests": dedupStats,
 			},
 		}
-
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			logger.Error("Failed to encode status response", "error", err)
 		}
-	})
-
-	// All other routes go through secured MCP handler
-	mux.Handle("/", securedHandler)
-
-	// Create HTTP server with timeouts
-	httpServer := &http.Server{
-		Addr:         addr,
-		Handler:      mux,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 60 * time.Second,
-		IdleTimeout:  120 * time.Second,
 	}
+}
 
-	// Log startup info
-	logger.Info("Starting MediaWiki MCP Server (HTTP mode)",
+// logStartup emits the server startup info line.
+func logStartup(cfg httpServerConfig, allowedOrigins []string) {
+	cfg.Logger.Info("Starting MediaWiki MCP Server (HTTP mode)",
 		"name", ServerName,
 		"version", ServerVersion,
-		"address", addr,
-		"wiki_url", wikiURL,
-		"auth_enabled", authToken != "",
-		"rate_limit", rateLimit,
-		"allowed_origins", allowedOriginsList,
+		"address", cfg.Addr,
+		"wiki_url", cfg.WikiURL,
+		"auth_enabled", cfg.AuthToken != "",
+		"rate_limit", cfg.RateLimit,
+		"allowed_origins", allowedOrigins,
 	)
+}
 
-	// Warm cache in background (don't block startup)
+// warmCacheAsync warms the client cache in the background without blocking
+// startup.
+func warmCacheAsync(client *wiki.Client, logger *slog.Logger) {
 	go func() {
 		warmCtx, warmCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer warmCancel()
@@ -204,20 +236,24 @@ func runHTTPServer(server *mcp.Server, logger *slog.Logger, addr, authToken, ori
 			logger.Info("Cache warming completed")
 		}
 	}()
+}
 
-	// Security warnings
+// logSecurityWarnings warns about insecure configurations at startup.
+func logSecurityWarnings(logger *slog.Logger, authToken, addr string) {
 	if authToken == "" {
 		logger.Warn("HTTP server running WITHOUT authentication. Set -token flag or MCP_AUTH_TOKEN env var for production use.")
 	}
 	if !strings.HasPrefix(addr, "127.0.0.1") && !strings.HasPrefix(addr, "localhost") {
 		logger.Warn("Server binding to external interface. Ensure you're behind HTTPS proxy in production.")
 	}
+}
 
-	// Set up signal handling for graceful shutdown
+// serveUntilSignal starts the HTTP server and blocks until a shutdown signal or
+// a fatal server error arrives.
+func serveUntilSignal(httpServer *http.Server, logger *slog.Logger) {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
-	// Start server in a goroutine
 	serverErrors := make(chan error, 1)
 	go func() {
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -226,28 +262,27 @@ func runHTTPServer(server *mcp.Server, logger *slog.Logger, addr, authToken, ori
 		close(serverErrors)
 	}()
 
-	// Wait for shutdown signal or server error
 	select {
 	case err := <-serverErrors:
 		log.Fatalf("HTTP server error: %v", err)
 	case sig := <-sigChan:
 		logger.Info("Shutdown signal received", "signal", sig.String())
 	}
+}
 
-	// Graceful shutdown with timeout
+// shutdownServer performs the graceful shutdown sequence and resource cleanup.
+func shutdownServer(httpServer *http.Server, securedHandler *SecurityMiddleware, client *wiki.Client, logger *slog.Logger) {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
 
 	logger.Info("Initiating graceful shutdown...")
 
-	// Stop accepting new connections and wait for existing requests
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("HTTP server shutdown error", "error", err)
 	} else {
 		logger.Info("HTTP server stopped gracefully")
 	}
 
-	// Clean up resources
 	if securedHandler.rateLimiter != nil {
 		securedHandler.rateLimiter.Close()
 		logger.Info("Rate limiter stopped")
@@ -344,33 +379,53 @@ func registerResources(server *mcp.Server, client *wiki.Client, logger *slog.Log
 		Name:        "Wiki Page",
 		Description: "Access MediaWiki page content directly. Use URL-encoded page titles (e.g., 'Main_Page' or 'Category%3AHelp').",
 		MIMEType:    "text/plain",
-	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-		defer func() {
-			if r := recover(); r != nil {
-				logger.Error("Panic recovered in resource handler",
-					"panic", r,
-					"stack", string(debug.Stack()))
-			}
-		}()
+	}, makePageResourceHandler(client, logger))
 
-		// Extract page title from URI
-		// URI format: wiki://page/{title}
+	// Resource template for wiki categories
+	// URI format: wiki://category/{name}
+	server.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: "wiki://category/{name}",
+		Name:        "Wiki Category",
+		Description: "List pages in a MediaWiki category. Use URL-encoded category names without 'Category:' prefix.",
+		MIMEType:    "application/json",
+	}, makeCategoryResourceHandler(client, logger))
+}
+
+// recoverResourceHandler logs a recovered panic from a resource handler.
+func recoverResourceHandler(logger *slog.Logger, context string) {
+	if r := recover(); r != nil {
+		logger.Error("Panic recovered in "+context,
+			"panic", r,
+			"stack", string(debug.Stack()))
+	}
+}
+
+// decodeResourceTitle validates the URI prefix and returns the decoded segment.
+func decodeResourceTitle(uri, prefix, label string) (string, error) {
+	if !strings.HasPrefix(uri, prefix) {
+		return "", mcp.ResourceNotFoundError(uri)
+	}
+	decoded, err := url.PathUnescape(strings.TrimPrefix(uri, prefix))
+	if err != nil {
+		return "", fmt.Errorf("invalid %s encoding: %w", label, err)
+	}
+	if decoded == "" {
+		return "", fmt.Errorf("%s cannot be empty", label)
+	}
+	return decoded, nil
+}
+
+// makePageResourceHandler returns the wiki://page/{title} resource handler.
+func makePageResourceHandler(client *wiki.Client, logger *slog.Logger) func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		defer recoverResourceHandler(logger, "resource handler")
+
 		uri := req.Params.URI
-		if !strings.HasPrefix(uri, "wiki://page/") {
-			return nil, mcp.ResourceNotFoundError(uri)
-		}
-
-		encodedTitle := strings.TrimPrefix(uri, "wiki://page/")
-		title, err := url.PathUnescape(encodedTitle)
+		title, err := decodeResourceTitle(uri, "wiki://page/", "page title")
 		if err != nil {
-			return nil, fmt.Errorf("invalid page title encoding: %w", err)
+			return nil, err
 		}
 
-		if title == "" {
-			return nil, fmt.Errorf("page title cannot be empty")
-		}
-
-		// Fetch page content (wikitext format for better context)
 		result, err := client.GetPage(ctx, wiki.GetPageArgs{
 			Title:  title,
 			Format: "wikitext",
@@ -397,37 +452,18 @@ func registerResources(server *mcp.Server, client *wiki.Client, logger *slog.Log
 				Text:     result.Content,
 			}},
 		}, nil
-	})
+	}
+}
 
-	// Resource template for wiki categories
-	// URI format: wiki://category/{name}
-	server.AddResourceTemplate(&mcp.ResourceTemplate{
-		URITemplate: "wiki://category/{name}",
-		Name:        "Wiki Category",
-		Description: "List pages in a MediaWiki category. Use URL-encoded category names without 'Category:' prefix.",
-		MIMEType:    "application/json",
-	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-		defer func() {
-			if r := recover(); r != nil {
-				logger.Error("Panic recovered in category resource handler",
-					"panic", r,
-					"stack", string(debug.Stack()))
-			}
-		}()
+// makeCategoryResourceHandler returns the wiki://category/{name} resource handler.
+func makeCategoryResourceHandler(client *wiki.Client, logger *slog.Logger) func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		defer recoverResourceHandler(logger, "category resource handler")
 
 		uri := req.Params.URI
-		if !strings.HasPrefix(uri, "wiki://category/") {
-			return nil, mcp.ResourceNotFoundError(uri)
-		}
-
-		encodedName := strings.TrimPrefix(uri, "wiki://category/")
-		name, err := url.PathUnescape(encodedName)
+		name, err := decodeResourceTitle(uri, "wiki://category/", "category name")
 		if err != nil {
-			return nil, fmt.Errorf("invalid category name encoding: %w", err)
-		}
-
-		if name == "" {
-			return nil, fmt.Errorf("category name cannot be empty")
+			return nil, err
 		}
 
 		result, err := client.GetCategoryMembers(ctx, wiki.CategoryMembersArgs{
@@ -467,5 +503,5 @@ func registerResources(server *mcp.Server, client *wiki.Client, logger *slog.Log
 				Text:     content.String(),
 			}},
 		}, nil
-	})
+	}
 }

--- a/wiki/batch.go
+++ b/wiki/batch.go
@@ -74,17 +74,47 @@ func buildPageContentResult(page map[string]interface{}, format string) (PageCon
 	return pageResult, pageStatusOK
 }
 
+// capBatchTitles validates the title list is non-empty and caps it at
+// MaxBatchSize, returning a descriptive error when empty.
+func capBatchTitles(titles []string) ([]string, error) {
+	if len(titles) == 0 {
+		return nil, fmt.Errorf("at least one title is required")
+	}
+	if len(titles) > MaxBatchSize {
+		return titles[:MaxBatchSize], nil
+	}
+	return titles, nil
+}
+
+// normalizeTitles returns the per-title normalized form, preserving order.
+func normalizeTitles(titles []string) []string {
+	normalized := make([]string, len(titles))
+	for i, t := range titles {
+		normalized[i] = normalizePageTitle(t)
+	}
+	return normalized
+}
+
+// extractQueryPages pulls the query and pages objects out of an API response,
+// returning shape errors labeled with the given context.
+func extractQueryPages(resp map[string]interface{}, label string) (query, pages map[string]interface{}, err error) {
+	query = getMap(resp["query"])
+	if query == nil {
+		return nil, nil, fmt.Errorf("%s: missing query", label)
+	}
+	pages = getMap(query["pages"])
+	if pages == nil {
+		return nil, nil, fmt.Errorf("%s: missing pages", label)
+	}
+	return query, pages, nil
+}
+
 // GetPagesBatch retrieves content for multiple pages in a single API call.
 // This is significantly more efficient than calling GetPage individually.
 func (c *Client) GetPagesBatch(ctx context.Context, args GetPagesBatchArgs) (GetPagesBatchResult, error) {
-	if len(args.Titles) == 0 {
-		return GetPagesBatchResult{}, fmt.Errorf("at least one title is required")
-	}
-
-	// Enforce batch size limit
-	titles := args.Titles
-	if len(titles) > MaxBatchSize {
-		titles = titles[:MaxBatchSize]
+	titles, err := capBatchTitles(args.Titles)
+	if err != nil {
+		return GetPagesBatchResult{}, err
 	}
 
 	if err := c.EnsureLoggedIn(ctx); err != nil {
@@ -101,19 +131,10 @@ func (c *Client) GetPagesBatch(ctx context.Context, args GetPagesBatchArgs) (Get
 		TotalCount: len(titles),
 	}
 
-	// Normalize all titles
-	normalizedTitles := make([]string, len(titles))
-	titleMap := make(map[string]string) // normalized -> original
-	for i, t := range titles {
-		normalized := normalizePageTitle(t)
-		normalizedTitles[i] = normalized
-		titleMap[normalized] = t
-	}
-
 	// MediaWiki API accepts pipe-separated titles
 	params := url.Values{}
 	params.Set("action", "query")
-	params.Set("titles", strings.Join(normalizedTitles, "|"))
+	params.Set("titles", strings.Join(normalizeTitles(titles), "|"))
 	params.Set("prop", "revisions")
 	params.Set("rvprop", "content|ids|timestamp")
 	params.Set("rvslots", "main")
@@ -122,20 +143,20 @@ func (c *Client) GetPagesBatch(ctx context.Context, args GetPagesBatchArgs) (Get
 	if err != nil {
 		return GetPagesBatchResult{}, fmt.Errorf("API request failed: %w", err)
 	}
-
-	query := getMap(resp["query"])
-	if query == nil {
-		return GetPagesBatchResult{}, fmt.Errorf("unexpected API response: missing 'query' object")
+	query, pages, err := extractQueryPages(resp, "unexpected API response")
+	if err != nil {
+		return GetPagesBatchResult{}, err
 	}
 
-	pages := getMap(query["pages"])
-	if pages == nil {
-		return GetPagesBatchResult{}, fmt.Errorf("unexpected API response: missing 'pages' object")
-	}
+	foundTitles := collectPageContentResults(pages, format, &result)
+	applyNormalizedMappings(query, foundTitles)
+	return result, nil
+}
 
-	// Track which pages we found
+// collectPageContentResults builds a PageContentResult for each page, updating
+// the batch counters, and returns the set of titles seen.
+func collectPageContentResults(pages map[string]interface{}, format string, result *GetPagesBatchResult) map[string]bool {
 	foundTitles := make(map[string]bool)
-
 	for _, pageData := range pages {
 		page := getMap(pageData)
 		if page == nil {
@@ -151,35 +172,30 @@ func (c *Client) GetPagesBatch(ctx context.Context, args GetPagesBatchArgs) (Get
 		foundTitles[pageResult.Title] = true
 		result.Pages = append(result.Pages, pageResult)
 	}
+	return foundTitles
+}
 
-	// Handle normalized titles that weren't found in response
-	if normalized := getMap(query["normalized"]); normalized != nil {
-		// MediaWiki returns normalized mappings
-		for _, n := range getSlice(query["normalized"]) {
-			normMap := getMap(n)
-			if normMap != nil {
-				from := getString(normMap["from"])
-				to := getString(normMap["to"])
-				if from != "" && to != "" {
-					foundTitles[from] = foundTitles[to]
-				}
-			}
+// applyNormalizedMappings propagates found-status across MediaWiki's
+// normalized title mappings (from -> to).
+func applyNormalizedMappings(query map[string]interface{}, foundTitles map[string]bool) {
+	for _, n := range getSlice(query["normalized"]) {
+		normMap := getMap(n)
+		if normMap == nil {
+			continue
+		}
+		from := getString(normMap["from"])
+		to := getString(normMap["to"])
+		if from != "" && to != "" {
+			foundTitles[from] = foundTitles[to]
 		}
 	}
-
-	return result, nil
 }
 
 // GetPagesInfoBatch retrieves metadata for multiple pages in a single API call.
 func (c *Client) GetPagesInfoBatch(ctx context.Context, args GetPagesInfoBatchArgs) (GetPagesInfoBatchResult, error) {
-	if len(args.Titles) == 0 {
-		return GetPagesInfoBatchResult{}, fmt.Errorf("at least one title is required")
-	}
-
-	// Enforce batch size limit
-	titles := args.Titles
-	if len(titles) > MaxBatchSize {
-		titles = titles[:MaxBatchSize]
+	titles, err := capBatchTitles(args.Titles)
+	if err != nil {
+		return GetPagesInfoBatchResult{}, err
 	}
 
 	if err := c.EnsureLoggedIn(ctx); err != nil {
@@ -191,15 +207,9 @@ func (c *Client) GetPagesInfoBatch(ctx context.Context, args GetPagesInfoBatchAr
 		TotalCount: len(titles),
 	}
 
-	// Normalize all titles
-	normalizedTitles := make([]string, len(titles))
-	for i, t := range titles {
-		normalizedTitles[i] = normalizePageTitle(t)
-	}
-
 	params := url.Values{}
 	params.Set("action", "query")
-	params.Set("titles", strings.Join(normalizedTitles, "|"))
+	params.Set("titles", strings.Join(normalizeTitles(titles), "|"))
 	params.Set("prop", "info|categories")
 	params.Set("inprop", "protection|url")
 	params.Set("cllimit", "50")
@@ -209,76 +219,81 @@ func (c *Client) GetPagesInfoBatch(ctx context.Context, args GetPagesInfoBatchAr
 		return GetPagesInfoBatchResult{}, err
 	}
 
-	query := getMap(resp["query"])
-	if query == nil {
-		return GetPagesInfoBatchResult{}, fmt.Errorf("unexpected response format: missing query")
+	_, pages, err := extractQueryPages(resp, "unexpected response format")
+	if err != nil {
+		return GetPagesInfoBatchResult{}, err
 	}
 
-	pages := getMap(query["pages"])
-	if pages == nil {
-		return GetPagesInfoBatchResult{}, fmt.Errorf("unexpected response format: missing pages")
-	}
+	collectPageInfos(pages, &result)
+	return result, nil
+}
 
+// collectPageInfos builds a PageInfo for each page and updates the batch
+// exists/missing counters.
+func collectPageInfos(pages map[string]interface{}, result *GetPagesInfoBatchResult) {
 	for _, pageData := range pages {
 		page := getMap(pageData)
 		if page == nil {
 			continue
 		}
-
-		title := getString(page["title"])
-		info := PageInfo{
-			Title: title,
-		}
-
-		// Check if page exists
-		if _, missing := page["missing"]; missing {
-			info.Exists = false
+		info, exists := buildPageInfo(page)
+		if exists {
+			result.ExistsCount++
+		} else {
 			result.MissingCount++
-			result.Pages = append(result.Pages, info)
-			continue
 		}
-
-		info.Exists = true
-		info.PageID = getInt(page["pageid"])
-		info.Namespace = getInt(page["ns"])
-		info.ContentModel = getString(page["contentmodel"])
-		info.PageLanguage = getString(page["pagelanguage"])
-		info.Length = getInt(page["length"])
-		info.Touched = getString(page["touched"])
-		info.LastRevision = getInt(page["lastrevid"])
-		result.ExistsCount++
-
-		// Categories
-		if cats := getSlice(page["categories"]); cats != nil {
-			for _, cat := range cats {
-				catMap := getMap(cat)
-				if catMap != nil {
-					info.Categories = append(info.Categories, getString(catMap["title"]))
-				}
-			}
-		}
-
-		// Redirect
-		if _, isRedirect := page["redirect"]; isRedirect {
-			info.Redirect = true
-		}
-
-		// Protection
-		if protection := getSlice(page["protection"]); protection != nil {
-			for _, p := range protection {
-				prot := getMap(p)
-				if prot != nil {
-					protType := getString(prot["type"])
-					protLevel := getString(prot["level"])
-					info.Protection = append(info.Protection, fmt.Sprintf("%s: %s", protType, protLevel))
-				}
-			}
-		}
-
 		result.Pages = append(result.Pages, info)
 	}
+}
 
-	return result, nil
+// buildPageInfo converts one MediaWiki page metadata object into a PageInfo and
+// reports whether the page exists.
+func buildPageInfo(page map[string]interface{}) (PageInfo, bool) {
+	info := PageInfo{Title: getString(page["title"])}
+
+	if _, missing := page["missing"]; missing {
+		info.Exists = false
+		return info, false
+	}
+
+	info.Exists = true
+	info.PageID = getInt(page["pageid"])
+	info.Namespace = getInt(page["ns"])
+	info.ContentModel = getString(page["contentmodel"])
+	info.PageLanguage = getString(page["pagelanguage"])
+	info.Length = getInt(page["length"])
+	info.Touched = getString(page["touched"])
+	info.LastRevision = getInt(page["lastrevid"])
+	info.Categories = extractCategoryTitles(page["categories"])
+	if _, isRedirect := page["redirect"]; isRedirect {
+		info.Redirect = true
+	}
+	info.Protection = extractProtectionEntries(page["protection"])
+	return info, true
+}
+
+// extractCategoryTitles returns the category titles from a page's categories
+// slice.
+func extractCategoryTitles(raw interface{}) []string {
+	var titles []string
+	for _, cat := range getSlice(raw) {
+		if catMap := getMap(cat); catMap != nil {
+			titles = append(titles, getString(catMap["title"]))
+		}
+	}
+	return titles
+}
+
+// extractProtectionEntries returns "type: level" strings from a page's
+// protection slice.
+func extractProtectionEntries(raw interface{}) []string {
+	var entries []string
+	for _, p := range getSlice(raw) {
+		if prot := getMap(p); prot != nil {
+			entries = append(entries, fmt.Sprintf("%s: %s", getString(prot["type"]), getString(prot["level"])))
+		}
+	}
+	return entries
 }
 
 // SearchAndRead searches the wiki and reads the top result(s) in one operation.
@@ -288,13 +303,7 @@ func (c *Client) SearchAndRead(ctx context.Context, args SearchAndReadArgs) (Sea
 		return SearchAndReadResult{}, fmt.Errorf("query is required")
 	}
 
-	readCount := args.ReadCount
-	if readCount <= 0 {
-		readCount = 1
-	}
-	if readCount > 5 {
-		readCount = 5
-	}
+	readCount := clampReadCount(args.ReadCount)
 
 	format := args.Format
 	if format == "" {
@@ -325,23 +334,44 @@ func (c *Client) SearchAndRead(ctx context.Context, args SearchAndReadArgs) (Sea
 	if toRead > len(searchResult.Results) {
 		toRead = len(searchResult.Results)
 	}
+	result.Pages = c.readSearchHits(ctx, searchResult.Results[:toRead], format)
 
-	result.Pages = make([]SearchAndReadPage, 0, toRead)
-	for i := 0; i < toRead; i++ {
-		hit := searchResult.Results[i]
+	// Step 3: Include remaining search hits as summaries
+	if len(searchResult.Results) > toRead {
+		result.OtherHits = searchResult.Results[toRead:]
+	}
 
+	result.Message = fmt.Sprintf("Read %d of %d results for '%s'", len(result.Pages), searchResult.TotalHits, args.Query)
+	return result, nil
+}
+
+// clampReadCount bounds the requested read count to the supported 1..5 range.
+func clampReadCount(n int) int {
+	switch {
+	case n <= 0:
+		return 1
+	case n > 5:
+		return 5
+	default:
+		return n
+	}
+}
+
+// readSearchHits fetches each hit's page content, falling back to a snippet-only
+// entry when a page read fails.
+func (c *Client) readSearchHits(ctx context.Context, hits []SearchHit, format string) []SearchAndReadPage {
+	pages := make([]SearchAndReadPage, 0, len(hits))
+	for _, hit := range hits {
 		page, err := c.GetPage(ctx, GetPageArgs{Title: hit.Title, Format: format})
 		if err != nil {
-			// Include the hit but without content
-			result.Pages = append(result.Pages, SearchAndReadPage{
+			pages = append(pages, SearchAndReadPage{
 				Title:   hit.Title,
 				PageID:  hit.PageID,
 				Snippet: hit.Snippet,
 			})
 			continue
 		}
-
-		result.Pages = append(result.Pages, SearchAndReadPage{
+		pages = append(pages, SearchAndReadPage{
 			Title:     page.Title,
 			PageID:    page.PageID,
 			Snippet:   hit.Snippet,
@@ -352,12 +382,5 @@ func (c *Client) SearchAndRead(ctx context.Context, args SearchAndReadArgs) (Sea
 			Truncated: page.Truncated,
 		})
 	}
-
-	// Step 3: Include remaining search hits as summaries
-	if len(searchResult.Results) > toRead {
-		result.OtherHits = searchResult.Results[toRead:]
-	}
-
-	result.Message = fmt.Sprintf("Read %d of %d results for '%s'", len(result.Pages), searchResult.TotalHits, args.Query)
-	return result, nil
+	return pages
 }

--- a/wiki/client_auth.go
+++ b/wiki/client_auth.go
@@ -85,85 +85,58 @@ func (c *Client) login(ctx context.Context) error {
 	// likely timed out." from the wiki.
 	c.resetCookies()
 
-	// Get login token
-	params := url.Values{}
-	params.Set("action", "query")
-	params.Set("meta", "tokens")
-	params.Set("type", "login")
-
-	resp, err := c.apiRequest(ctx, params)
+	loginToken, err := c.fetchLoginToken(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get login token: %w", err)
+		return err
 	}
 
-	query, ok := resp["query"].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("unexpected response format")
-	}
-
-	tokens, ok := query["tokens"].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("no tokens in response")
-	}
-
-	loginToken, ok := tokens["logintoken"].(string)
-	if !ok {
-		return fmt.Errorf("no login token in response")
-	}
-
-	// Perform login
-	params = url.Values{}
-	params.Set("action", "login")
-	params.Set("lgname", c.config.Username)
-	params.Set("lgpassword", c.config.Password)
-	params.Set("lgtoken", loginToken)
-
-	resp, err = c.apiRequest(ctx, params)
+	login, err := c.performLoginRequest(ctx, loginToken)
 	if err != nil {
-		// Check for BotPasswordSessionProvider error and retry with fresh cookies
+		// A BotPasswordSessionProvider conflict on the request itself: retry once
+		// with fresh cookies.
 		if strings.Contains(err.Error(), "BotPasswordSessionProvider") {
 			c.logger.Warn("BotPasswordSessionProvider conflict detected, resetting cookies")
 			c.resetCookies()
-			// Retry login once with fresh cookies
 			return c.loginFresh(ctx)
 		}
 		return fmt.Errorf("login failed: %w", err)
 	}
 
-	login, ok := resp["login"].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("unexpected login response")
-	}
-
-	result, ok := login["result"].(string)
-	if !ok {
-		return fmt.Errorf("login result not a string")
-	}
-	if result != "Success" {
-		reason := login["reason"]
-		// Check for BotPasswordSessionProvider in the reason
-		if reason != nil {
-			reasonStr := fmt.Sprintf("%v", reason)
-			if strings.Contains(reasonStr, "BotPasswordSessionProvider") {
-				c.logger.Warn("BotPasswordSessionProvider conflict in login result, resetting cookies")
-				c.resetCookies()
-				return c.loginFresh(ctx)
-			}
-			return fmt.Errorf("login failed: %s - %v", result, reason)
+	if err := c.checkLoginResult(login); err != nil {
+		// A BotPasswordSessionProvider conflict reported in the result: retry once.
+		if isBotPasswordSessionConflict(login) {
+			c.logger.Warn("BotPasswordSessionProvider conflict in login result, resetting cookies")
+			c.resetCookies()
+			return c.loginFresh(ctx)
 		}
-		return fmt.Errorf("login failed: %s", result)
+		return err
 	}
 
-	c.loggedIn = true
-	c.tokenExpiry = time.Now().Add(60 * time.Minute) // Extended from 20 to 60 minutes
-
-	c.logger.Info("Successfully logged in", "username", c.config.Username)
-
+	c.markLoggedIn("Successfully logged in")
 	return nil
 }
 
 func (c *Client) loginFresh(ctx context.Context) error {
-	// Get login token
+	loginToken, err := c.fetchLoginToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	login, err := c.performLoginRequest(ctx, loginToken)
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	if err := c.checkLoginResult(login); err != nil {
+		return err
+	}
+
+	c.markLoggedIn("Successfully logged in with fresh session")
+	return nil
+}
+
+// fetchLoginToken requests a fresh login token from the wiki.
+func (c *Client) fetchLoginToken(ctx context.Context) (string, error) {
 	params := url.Values{}
 	params.Set("action", "query")
 	params.Set("meta", "tokens")
@@ -171,59 +144,73 @@ func (c *Client) loginFresh(ctx context.Context) error {
 
 	resp, err := c.apiRequest(ctx, params)
 	if err != nil {
-		return fmt.Errorf("failed to get login token: %w", err)
+		return "", fmt.Errorf("failed to get login token: %w", err)
 	}
-
 	query, ok := resp["query"].(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("unexpected response format")
+		return "", fmt.Errorf("unexpected response format")
 	}
-
 	tokens, ok := query["tokens"].(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("no tokens in response")
+		return "", fmt.Errorf("no tokens in response")
 	}
-
 	loginToken, ok := tokens["logintoken"].(string)
 	if !ok {
-		return fmt.Errorf("no login token in response")
+		return "", fmt.Errorf("no login token in response")
 	}
+	return loginToken, nil
+}
 
-	// Perform login
-	params = url.Values{}
+// performLoginRequest sends the login action and returns the login response map.
+func (c *Client) performLoginRequest(ctx context.Context, loginToken string) (map[string]interface{}, error) {
+	params := url.Values{}
 	params.Set("action", "login")
 	params.Set("lgname", c.config.Username)
 	params.Set("lgpassword", c.config.Password)
 	params.Set("lgtoken", loginToken)
 
-	resp, err = c.apiRequest(ctx, params)
+	resp, err := c.apiRequest(ctx, params)
 	if err != nil {
-		return fmt.Errorf("login failed: %w", err)
+		return nil, err
 	}
-
 	login, ok := resp["login"].(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("unexpected login response")
+		return nil, fmt.Errorf("unexpected login response")
 	}
+	return login, nil
+}
 
+// checkLoginResult returns nil when the login result is "Success", otherwise a
+// descriptive error including the wiki's reason if present.
+func (c *Client) checkLoginResult(login map[string]interface{}) error {
 	result, ok := login["result"].(string)
 	if !ok {
 		return fmt.Errorf("login result not a string")
 	}
-	if result != "Success" {
-		reason := login["reason"]
-		if reason != nil {
-			return fmt.Errorf("login failed: %s - %v", result, reason)
-		}
-		return fmt.Errorf("login failed: %s", result)
+	if result == "Success" {
+		return nil
 	}
+	if reason := login["reason"]; reason != nil {
+		return fmt.Errorf("login failed: %s - %v", result, reason)
+	}
+	return fmt.Errorf("login failed: %s", result)
+}
 
+// isBotPasswordSessionConflict reports whether the login result's reason names a
+// BotPasswordSessionProvider conflict (retryable with fresh cookies).
+func isBotPasswordSessionConflict(login map[string]interface{}) bool {
+	reason := login["reason"]
+	if reason == nil {
+		return false
+	}
+	return strings.Contains(fmt.Sprintf("%v", reason), "BotPasswordSessionProvider")
+}
+
+// markLoggedIn records a successful login and refreshes the token expiry.
+func (c *Client) markLoggedIn(logMsg string) {
 	c.loggedIn = true
 	c.tokenExpiry = time.Now().Add(60 * time.Minute)
-
-	c.logger.Info("Successfully logged in with fresh session", "username", c.config.Username)
-
-	return nil
+	c.logger.Info(logMsg, "username", c.config.Username)
 }
 
 func (c *Client) getCSRFToken(ctx context.Context) (string, error) {

--- a/wiki/history.go
+++ b/wiki/history.go
@@ -16,38 +16,7 @@ func (c *Client) GetRecentChanges(ctx context.Context, args RecentChangesArgs) (
 		return RecentChangesResult{}, err
 	}
 
-	limit := normalizeLimit(args.Limit, DefaultLimit, MaxLimit)
-
-	params := url.Values{}
-	params.Set("action", "query")
-	params.Set("list", "recentchanges")
-	params.Set("rclimit", strconv.Itoa(limit))
-	params.Set("rcprop", "title|ids|sizes|flags|user|timestamp|comment")
-
-	if args.Namespace >= 0 {
-		params.Set("rcnamespace", strconv.Itoa(args.Namespace))
-	}
-
-	if args.Type != "" {
-		params.Set("rctype", args.Type)
-	}
-
-	if args.ContinueFrom != "" {
-		params.Set("rccontinue", args.ContinueFrom)
-	}
-
-	// rcdir defaults to "older" — same caller-friendly swap as GetRevisions.
-	// args.Start is the lower (older) bound, args.End is the upper (newer)
-	// bound. See the comment in GetRevisions for the full reasoning.
-	if args.Start != "" {
-		params.Set("rcend", args.Start)
-	}
-
-	if args.End != "" {
-		params.Set("rcstart", args.End)
-	}
-
-	resp, err := c.apiRequest(ctx, params)
+	resp, err := c.apiRequest(ctx, buildRecentChangesParams(args))
 	if err != nil {
 		return RecentChangesResult{}, err
 	}
@@ -61,15 +30,74 @@ func (c *Client) GetRecentChanges(ctx context.Context, args RecentChangesArgs) (
 		return RecentChangesResult{}, fmt.Errorf("unexpected API response: missing 'recentchanges' list")
 	}
 
+	changes := parseRecentChanges(rcList)
+	result := RecentChangesResult{}
+	result.HasMore, result.ContinueFrom = recentChangesContinuation(resp)
+
+	// Handle aggregation if requested; an invalid aggregate_by falls through to
+	// returning raw changes.
+	if args.AggregateBy != "" {
+		if aggregated := aggregateChanges(changes, args.AggregateBy); aggregated != nil {
+			result.Aggregated = aggregated
+			return result, nil
+		}
+	}
+
+	result.Changes = changes
+	return result, nil
+}
+
+// recentChangesContinuation extracts the rccontinue token from the response.
+func recentChangesContinuation(resp map[string]interface{}) (hasMore bool, continueFrom string) {
+	cont, ok := resp["continue"].(map[string]interface{})
+	if !ok {
+		return false, ""
+	}
+	rccontinue, ok := cont["rccontinue"].(string)
+	if !ok {
+		return false, ""
+	}
+	return true, rccontinue
+}
+
+// buildRecentChangesParams assembles the recentchanges query parameters.
+func buildRecentChangesParams(args RecentChangesArgs) url.Values {
+	limit := normalizeLimit(args.Limit, DefaultLimit, MaxLimit)
+
+	params := url.Values{}
+	params.Set("action", "query")
+	params.Set("list", "recentchanges")
+	params.Set("rclimit", strconv.Itoa(limit))
+	params.Set("rcprop", "title|ids|sizes|flags|user|timestamp|comment")
+	if args.Namespace >= 0 {
+		params.Set("rcnamespace", strconv.Itoa(args.Namespace))
+	}
+	if args.Type != "" {
+		params.Set("rctype", args.Type)
+	}
+	if args.ContinueFrom != "" {
+		params.Set("rccontinue", args.ContinueFrom)
+	}
+	// rcdir defaults to "older" — same caller-friendly swap as GetRevisions.
+	// args.Start is the lower (older) bound, args.End is the upper (newer) bound.
+	if args.Start != "" {
+		params.Set("rcend", args.Start)
+	}
+	if args.End != "" {
+		params.Set("rcstart", args.End)
+	}
+	return params
+}
+
+// parseRecentChanges converts the recentchanges list into RecentChange values.
+func parseRecentChanges(rcList []interface{}) []RecentChange {
 	changes := make([]RecentChange, 0, len(rcList))
 	for _, rc := range rcList {
 		change, ok := rc.(map[string]interface{})
 		if !ok {
 			continue
 		}
-
 		ts, _ := time.Parse(time.RFC3339, getString(change["timestamp"]))
-
 		changes = append(changes, RecentChange{
 			Type:       getString(change["type"]),
 			Title:      getString(change["title"]),
@@ -84,29 +112,7 @@ func (c *Client) GetRecentChanges(ctx context.Context, args RecentChangesArgs) (
 			Bot:        change["bot"] != nil,
 		})
 	}
-
-	result := RecentChangesResult{}
-
-	// Check for continuation
-	if cont, ok := resp["continue"].(map[string]interface{}); ok {
-		if rccontinue, ok := cont["rccontinue"].(string); ok {
-			result.HasMore = true
-			result.ContinueFrom = rccontinue
-		}
-	}
-
-	// Handle aggregation if requested
-	if args.AggregateBy != "" {
-		aggregated := aggregateChanges(changes, args.AggregateBy)
-		if aggregated != nil {
-			result.Aggregated = aggregated
-			return result, nil
-		}
-		// Invalid aggregate_by value, fall through to return raw changes
-	}
-
-	result.Changes = changes
-	return result, nil
+	return changes
 }
 
 // GetRevisions retrieves the revision history of a page
@@ -119,6 +125,69 @@ func (c *Client) GetRevisions(ctx context.Context, args GetRevisionsArgs) (GetRe
 		return GetRevisionsResult{}, err
 	}
 
+	resp, err := c.apiRequest(ctx, buildGetRevisionsParams(args))
+	if err != nil {
+		return GetRevisionsResult{}, err
+	}
+
+	query, ok := resp["query"].(map[string]interface{})
+	if !ok {
+		return GetRevisionsResult{}, fmt.Errorf("unexpected response format")
+	}
+
+	pages, ok := query["pages"].(map[string]interface{})
+	if !ok {
+		return GetRevisionsResult{}, fmt.Errorf("pages not found in response")
+	}
+
+	result := GetRevisionsResult{
+		Title:     args.Title,
+		Revisions: make([]RevisionInfo, 0),
+	}
+	complete, err := populateRevisions(pages, args.Title, &result)
+	if err != nil {
+		return GetRevisionsResult{}, err
+	}
+	if !complete {
+		// A page with no revisions array returns early without count or
+		// continuation, matching the original control flow.
+		return result, nil
+	}
+
+	result.Count = len(result.Revisions)
+	if _, ok := resp["continue"]; ok {
+		result.HasMore = true
+	}
+	return result, nil
+}
+
+// populateRevisions fills result from the first valid page object in pages. A
+// negative page ID means the page was not found. complete is false when the
+// page lacked a revisions array (caller returns immediately in that case).
+func populateRevisions(pages map[string]interface{}, title string, result *GetRevisionsResult) (complete bool, err error) {
+	for pageIDStr, pageData := range pages {
+		pageID, _ := strconv.Atoi(pageIDStr)
+		if pageID < 0 {
+			return false, fmt.Errorf("page '%s' not found", title)
+		}
+		page, ok := pageData.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result.PageID = pageID
+		result.Title = getString(page["title"])
+		revisions, ok := page["revisions"].([]interface{})
+		if !ok {
+			return false, nil
+		}
+		result.Revisions = parseRevisionInfos(revisions)
+		break // Only process first page
+	}
+	return true, nil
+}
+
+// buildGetRevisionsParams assembles the revision-history query parameters.
+func buildGetRevisionsParams(args GetRevisionsArgs) url.Values {
 	limit := normalizeLimit(args.Limit, 20, 100)
 
 	params := url.Values{}
@@ -141,117 +210,52 @@ func (c *Client) GetRevisions(ctx context.Context, args GetRevisionsArgs) (GetRe
 	if args.User != "" {
 		params.Set("rvuser", args.User)
 	}
+	return params
+}
 
-	resp, err := c.apiRequest(ctx, params)
-	if err != nil {
-		return GetRevisionsResult{}, err
-	}
-
-	query, ok := resp["query"].(map[string]interface{})
-	if !ok {
-		return GetRevisionsResult{}, fmt.Errorf("unexpected response format")
-	}
-
-	pages, ok := query["pages"].(map[string]interface{})
-	if !ok {
-		return GetRevisionsResult{}, fmt.Errorf("pages not found in response")
-	}
-
-	result := GetRevisionsResult{
-		Title:     args.Title,
-		Revisions: make([]RevisionInfo, 0),
-	}
-
-	for pageIDStr, pageData := range pages {
-		pageID, _ := strconv.Atoi(pageIDStr)
-		if pageID < 0 {
-			return GetRevisionsResult{}, fmt.Errorf("page '%s' not found", args.Title)
-		}
-
-		page, ok := pageData.(map[string]interface{})
+// parseRevisionInfos converts the revisions list into RevisionInfo values,
+// computing the per-revision size diff relative to the previous entry.
+func parseRevisionInfos(revisions []interface{}) []RevisionInfo {
+	infos := make([]RevisionInfo, 0, len(revisions))
+	var prevSize int
+	for i, rev := range revisions {
+		r, ok := rev.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		result.PageID = pageID
-		result.Title = getString(page["title"])
-
-		revisions, ok := page["revisions"].([]interface{})
-		if !ok {
-			return result, nil
+		info := RevisionInfo{
+			RevID:     getInt(r["revid"]),
+			ParentID:  getInt(r["parentid"]),
+			User:      getString(r["user"]),
+			Timestamp: getString(r["timestamp"]),
+			Size:      getInt(r["size"]),
+			Comment:   getString(r["comment"]),
 		}
-
-		var prevSize int
-		for i, rev := range revisions {
-			r, ok := rev.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			info := RevisionInfo{
-				RevID:     getInt(r["revid"]),
-				ParentID:  getInt(r["parentid"]),
-				User:      getString(r["user"]),
-				Timestamp: getString(r["timestamp"]),
-				Size:      getInt(r["size"]),
-				Comment:   getString(r["comment"]),
-			}
-
-			if _, isMinor := r["minor"]; isMinor {
-				info.Minor = true
-			}
-
-			// Calculate size diff
-			if i == 0 {
-				prevSize = info.Size
-			} else {
-				info.SizeDiff = info.Size - prevSize
-				prevSize = info.Size
-			}
-
-			result.Revisions = append(result.Revisions, info)
+		if _, isMinor := r["minor"]; isMinor {
+			info.Minor = true
 		}
-
-		break // Only process first page
+		if i == 0 {
+			prevSize = info.Size
+		} else {
+			info.SizeDiff = info.Size - prevSize
+			prevSize = info.Size
+		}
+		infos = append(infos, info)
 	}
-
-	result.Count = len(result.Revisions)
-
-	// Check for continuation
-	if _, ok := resp["continue"]; ok {
-		result.HasMore = true
-	}
-
-	return result, nil
+	return infos
 }
 
 // CompareRevisions compares two revisions and returns the diff
 func (c *Client) CompareRevisions(ctx context.Context, args CompareRevisionsArgs) (CompareRevisionsResult, error) {
-	if args.FromRev == 0 && args.FromTitle == "" {
-		return CompareRevisionsResult{}, fmt.Errorf("either from_rev or from_title is required")
-	}
-	if args.ToRev == 0 && args.ToTitle == "" {
-		return CompareRevisionsResult{}, fmt.Errorf("either to_rev or to_title is required")
+	if err := validateCompareArgs(args); err != nil {
+		return CompareRevisionsResult{}, err
 	}
 
 	if err := c.EnsureLoggedIn(ctx); err != nil {
 		return CompareRevisionsResult{}, err
 	}
 
-	params := url.Values{}
-	params.Set("action", "compare")
-
-	if args.FromRev > 0 {
-		params.Set("fromrev", strconv.Itoa(args.FromRev))
-	} else {
-		params.Set("fromtitle", args.FromTitle)
-	}
-
-	if args.ToRev > 0 {
-		params.Set("torev", strconv.Itoa(args.ToRev))
-	} else {
-		params.Set("totitle", args.ToTitle)
-	}
-
-	resp, err := c.apiRequest(ctx, params)
+	resp, err := c.apiRequest(ctx, buildCompareParams(args))
 	if err != nil {
 		return CompareRevisionsResult{}, err
 	}
@@ -281,6 +285,35 @@ func (c *Client) CompareRevisions(ctx context.Context, args CompareRevisionsArgs
 	return result, nil
 }
 
+// validateCompareArgs ensures each side has either a revision ID or a title.
+func validateCompareArgs(args CompareRevisionsArgs) error {
+	if args.FromRev == 0 && args.FromTitle == "" {
+		return fmt.Errorf("either from_rev or from_title is required")
+	}
+	if args.ToRev == 0 && args.ToTitle == "" {
+		return fmt.Errorf("either to_rev or to_title is required")
+	}
+	return nil
+}
+
+// buildCompareParams assembles the compare query parameters, preferring
+// revision IDs over titles for each side.
+func buildCompareParams(args CompareRevisionsArgs) url.Values {
+	params := url.Values{}
+	params.Set("action", "compare")
+	if args.FromRev > 0 {
+		params.Set("fromrev", strconv.Itoa(args.FromRev))
+	} else {
+		params.Set("fromtitle", args.FromTitle)
+	}
+	if args.ToRev > 0 {
+		params.Set("torev", strconv.Itoa(args.ToRev))
+	} else {
+		params.Set("totitle", args.ToTitle)
+	}
+	return params
+}
+
 // GetUserContributions returns the contributions (edits) made by a user
 func (c *Client) GetUserContributions(ctx context.Context, args GetUserContributionsArgs) (GetUserContributionsResult, error) {
 	if args.User == "" {
@@ -291,28 +324,7 @@ func (c *Client) GetUserContributions(ctx context.Context, args GetUserContribut
 		return GetUserContributionsResult{}, err
 	}
 
-	limit := normalizeLimit(args.Limit, 50, MaxLimit)
-
-	params := url.Values{}
-	params.Set("action", "query")
-	params.Set("list", "usercontribs")
-	params.Set("ucuser", args.User)
-	params.Set("ucprop", "ids|title|timestamp|comment|size|sizediff|flags")
-	params.Set("uclimit", strconv.Itoa(limit))
-
-	if args.Namespace >= 0 {
-		params.Set("ucnamespace", strconv.Itoa(args.Namespace))
-	}
-	// ucdir defaults to "older" — same caller-friendly swap as GetRevisions.
-	// See the comment in GetRevisions for the full reasoning.
-	if args.Start != "" {
-		params.Set("ucend", args.Start)
-	}
-	if args.End != "" {
-		params.Set("ucstart", args.End)
-	}
-
-	resp, err := c.apiRequest(ctx, params)
+	resp, err := c.apiRequest(ctx, buildUserContribsParams(args))
 	if err != nil {
 		return GetUserContributionsResult{}, err
 	}
@@ -329,9 +341,42 @@ func (c *Client) GetUserContributions(ctx context.Context, args GetUserContribut
 
 	result := GetUserContributionsResult{
 		User:          args.User,
-		Contributions: make([]UserContribution, 0, len(contribs)),
+		Contributions: parseUserContributions(contribs),
 	}
+	result.Count = len(result.Contributions)
+	if _, ok := resp["continue"]; ok {
+		result.HasMore = true
+	}
+	return result, nil
+}
 
+// buildUserContribsParams assembles the usercontribs query parameters.
+func buildUserContribsParams(args GetUserContributionsArgs) url.Values {
+	limit := normalizeLimit(args.Limit, 50, MaxLimit)
+
+	params := url.Values{}
+	params.Set("action", "query")
+	params.Set("list", "usercontribs")
+	params.Set("ucuser", args.User)
+	params.Set("ucprop", "ids|title|timestamp|comment|size|sizediff|flags")
+	params.Set("uclimit", strconv.Itoa(limit))
+	if args.Namespace >= 0 {
+		params.Set("ucnamespace", strconv.Itoa(args.Namespace))
+	}
+	// ucdir defaults to "older" — same caller-friendly swap as GetRevisions.
+	if args.Start != "" {
+		params.Set("ucend", args.Start)
+	}
+	if args.End != "" {
+		params.Set("ucstart", args.End)
+	}
+	return params
+}
+
+// parseUserContributions converts the usercontribs list into UserContribution
+// values.
+func parseUserContributions(contribs []interface{}) []UserContribution {
+	out := make([]UserContribution, 0, len(contribs))
 	for _, c := range contribs {
 		contrib, ok := c.(map[string]interface{})
 		if !ok {
@@ -348,25 +393,15 @@ func (c *Client) GetUserContributions(ctx context.Context, args GetUserContribut
 			Size:      getInt(contrib["size"]),
 			SizeDiff:  getInt(contrib["sizediff"]),
 		}
-
 		if _, isMinor := contrib["minor"]; isMinor {
 			uc.Minor = true
 		}
 		if _, isNew := contrib["new"]; isNew {
 			uc.New = true
 		}
-
-		result.Contributions = append(result.Contributions, uc)
+		out = append(out, uc)
 	}
-
-	result.Count = len(result.Contributions)
-
-	// Check for continuation
-	if _, ok := resp["continue"]; ok {
-		result.HasMore = true
-	}
-
-	return result, nil
+	return out
 }
 
 // aggregateChanges groups recent changes by the specified field

--- a/wiki/links.go
+++ b/wiki/links.go
@@ -73,19 +73,37 @@ func (c *Client) GetExternalLinks(ctx context.Context, args GetExternalLinksArgs
 	if !ok {
 		return ExternalLinksResult{}, fmt.Errorf("no pages in response")
 	}
+	return firstExternalLinksResult(pages, args.Title)
+}
 
+// firstExternalLinksResult returns the external-links result for the first
+// valid page object, or an error if that page is flagged missing.
+func firstExternalLinksResult(pages map[string]interface{}, requestedTitle string) (ExternalLinksResult, error) {
 	for _, pageData := range pages {
 		page, ok := pageData.(map[string]interface{})
 		if !ok {
 			continue
 		}
 		if _, missing := page["missing"]; missing {
-			return ExternalLinksResult{}, fmt.Errorf("page '%s' does not exist", args.Title)
+			return ExternalLinksResult{}, fmt.Errorf("page '%s' does not exist", requestedTitle)
 		}
 		title, links := extractExternalLinksFromPage(page)
 		return ExternalLinksResult{Title: title, Links: links, Count: len(links)}, nil
 	}
 	return ExternalLinksResult{Links: make([]ExternalLink, 0)}, nil
+}
+
+// extLinksJob is one unit of work for the external-links batch worker pool.
+type extLinksJob struct {
+	index int
+	title string
+}
+
+// extLinksPageResult carries one page's batch outcome plus its original index so
+// results can be reassembled in order.
+type extLinksPageResult struct {
+	index int
+	data  PageExternalLinks
 }
 
 // GetExternalLinksBatch retrieves external links from multiple wiki pages
@@ -96,84 +114,33 @@ func (c *Client) GetExternalLinksBatch(ctx context.Context, args GetExternalLink
 	}
 
 	// Limit batch size to prevent overwhelming the API
-	maxBatch := 10
+	const maxBatch = 10
 	if len(args.Titles) > maxBatch {
 		args.Titles = args.Titles[:maxBatch]
 	}
 
-	// Worker pool configuration
 	numWorkers := 4 // Limit concurrent API requests
 	if len(args.Titles) < numWorkers {
 		numWorkers = len(args.Titles)
 	}
 
-	// Job and result types
-	type job struct {
-		index int
-		title string
-	}
-	type pageResult struct {
-		index int
-		data  PageExternalLinks
-	}
+	jobs := make(chan extLinksJob, len(args.Titles))
+	results := make(chan extLinksPageResult, len(args.Titles))
 
-	jobs := make(chan job, len(args.Titles))
-	results := make(chan pageResult, len(args.Titles))
-
-	// Start workers
 	var wg sync.WaitGroup
 	for w := 0; w < numWorkers; w++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := range jobs {
-				// Check context cancellation
-				select {
-				case <-ctx.Done():
-					results <- pageResult{
-						index: j.index,
-						data: PageExternalLinks{
-							Title: j.title,
-							Links: make([]ExternalLink, 0),
-							Error: "request canceled",
-						},
-					}
-					continue
-				default:
-				}
-
-				pageLinks, err := c.GetExternalLinks(ctx, GetExternalLinksArgs{Title: j.title})
-				if err != nil {
-					results <- pageResult{
-						index: j.index,
-						data: PageExternalLinks{
-							Title: j.title,
-							Links: make([]ExternalLink, 0),
-							Error: err.Error(),
-						},
-					}
-					continue
-				}
-
-				results <- pageResult{
-					index: j.index,
-					data: PageExternalLinks{
-						Title: pageLinks.Title,
-						Links: pageLinks.Links,
-						Count: pageLinks.Count,
-					},
-				}
-			}
+			c.runExtLinksWorker(ctx, jobs, results)
 		}()
 	}
 
-	// Send jobs to workers
 	for i, title := range args.Titles {
-		jobs <- job{index: i, title: title}
+		jobs <- extLinksJob{index: i, title: title}
 	}
 	close(jobs)
 
-	// Close results channel when all workers complete
 	go func() {
 		wg.Wait()
 		close(results)
@@ -182,7 +149,6 @@ func (c *Client) GetExternalLinksBatch(ctx context.Context, args GetExternalLink
 	// Collect results maintaining order
 	pageResults := make([]PageExternalLinks, len(args.Titles))
 	totalLinks := 0
-
 	for pr := range results {
 		pageResults[pr.index] = pr.data
 		totalLinks += pr.data.Count
@@ -192,6 +158,36 @@ func (c *Client) GetExternalLinksBatch(ctx context.Context, args GetExternalLink
 		Pages:      pageResults,
 		TotalLinks: totalLinks,
 	}, nil
+}
+
+// runExtLinksWorker drains jobs, fetching each page's external links and
+// emitting an ordered result (including error/cancellation outcomes).
+func (c *Client) runExtLinksWorker(ctx context.Context, jobs <-chan extLinksJob, results chan<- extLinksPageResult) {
+	for j := range jobs {
+		select {
+		case <-ctx.Done():
+			results <- extLinksPageResult{
+				index: j.index,
+				data:  PageExternalLinks{Title: j.title, Links: make([]ExternalLink, 0), Error: "request canceled"},
+			}
+			continue
+		default:
+		}
+
+		pageLinks, err := c.GetExternalLinks(ctx, GetExternalLinksArgs{Title: j.title})
+		if err != nil {
+			results <- extLinksPageResult{
+				index: j.index,
+				data:  PageExternalLinks{Title: j.title, Links: make([]ExternalLink, 0), Error: err.Error()},
+			}
+			continue
+		}
+
+		results <- extLinksPageResult{
+			index: j.index,
+			data:  PageExternalLinks{Title: pageLinks.Title, Links: pageLinks.Links, Count: pageLinks.Count},
+		}
+	}
 }
 
 // CheckLinks checks if URLs are accessible (broken link detection)

--- a/wiki/pageinfo.go
+++ b/wiki/pageinfo.go
@@ -47,25 +47,7 @@ func (c *Client) ListPages(ctx context.Context, args ListPagesArgs) (ListPagesRe
 		return ListPagesResult{}, err
 	}
 
-	limit := normalizeLimit(args.Limit, DefaultLimit, MaxLimit)
-
-	params := url.Values{}
-	params.Set("action", "query")
-	params.Set("list", "allpages")
-	params.Set("aplimit", strconv.Itoa(limit))
-
-	if args.Prefix != "" {
-		params.Set("apprefix", args.Prefix)
-	}
-
-	if args.Namespace >= 0 {
-		params.Set("apnamespace", strconv.Itoa(args.Namespace))
-	}
-
-	if args.ContinueFrom != "" {
-		params.Set("apcontinue", args.ContinueFrom)
-	}
-
+	params := buildListPagesParams(args)
 	resp, err := c.apiRequest(ctx, params)
 	if err != nil {
 		return ListPagesResult{}, err
@@ -76,7 +58,46 @@ func (c *Client) ListPages(ctx context.Context, args ListPagesArgs) (ListPagesRe
 		return ListPagesResult{}, fmt.Errorf("unexpected response format: missing query")
 	}
 
-	allpages := getSlice(query["allpages"])
+	pages := parsePageSummaries(getSlice(query["allpages"]))
+	result := ListPagesResult{
+		Pages:         pages,
+		ReturnedCount: len(pages),
+		TotalCount:    len(pages), // Deprecated: kept for backwards compatibility
+	}
+	applyContinuation(resp, &result)
+
+	// Try to get namespace statistics for total estimate (only when no prefix filter)
+	if args.Prefix == "" && args.Namespace >= 0 {
+		if estimate := c.getNamespacePageCount(ctx, args.Namespace); estimate > 0 {
+			result.TotalEstimate = estimate
+		}
+	}
+
+	return result, nil
+}
+
+// buildListPagesParams assembles the allpages query parameters from args.
+func buildListPagesParams(args ListPagesArgs) url.Values {
+	limit := normalizeLimit(args.Limit, DefaultLimit, MaxLimit)
+
+	params := url.Values{}
+	params.Set("action", "query")
+	params.Set("list", "allpages")
+	params.Set("aplimit", strconv.Itoa(limit))
+	if args.Prefix != "" {
+		params.Set("apprefix", args.Prefix)
+	}
+	if args.Namespace >= 0 {
+		params.Set("apnamespace", strconv.Itoa(args.Namespace))
+	}
+	if args.ContinueFrom != "" {
+		params.Set("apcontinue", args.ContinueFrom)
+	}
+	return params
+}
+
+// parsePageSummaries converts allpages entries into PageSummary values.
+func parsePageSummaries(allpages []interface{}) []PageSummary {
 	pages := make([]PageSummary, 0, len(allpages))
 	for _, p := range allpages {
 		page := getMap(p)
@@ -88,29 +109,20 @@ func (c *Client) ListPages(ctx context.Context, args ListPagesArgs) (ListPagesRe
 			Title:  getString(page["title"]),
 		})
 	}
+	return pages
+}
 
-	result := ListPagesResult{
-		Pages:         pages,
-		ReturnedCount: len(pages),
-		TotalCount:    len(pages), // Deprecated: kept for backwards compatibility
+// applyContinuation sets HasMore/ContinueFrom from the response's continue
+// block, if present.
+func applyContinuation(resp map[string]interface{}, result *ListPagesResult) {
+	cont := getMap(resp["continue"])
+	if cont == nil {
+		return
 	}
-
-	// Check for continuation
-	if cont := getMap(resp["continue"]); cont != nil {
-		if apcontinue := getString(cont["apcontinue"]); apcontinue != "" {
-			result.HasMore = true
-			result.ContinueFrom = apcontinue
-		}
+	if apcontinue := getString(cont["apcontinue"]); apcontinue != "" {
+		result.HasMore = true
+		result.ContinueFrom = apcontinue
 	}
-
-	// Try to get namespace statistics for total estimate (only when no prefix filter)
-	if args.Prefix == "" && args.Namespace >= 0 {
-		if estimate := c.getNamespacePageCount(ctx, args.Namespace); estimate > 0 {
-			result.TotalEstimate = estimate
-		}
-	}
-
-	return result, nil
 }
 
 // GetPageInfo gets metadata about a page
@@ -156,71 +168,57 @@ func (c *Client) GetPageInfo(ctx context.Context, args PageInfoArgs) (PageInfo, 
 		return PageInfo{}, fmt.Errorf("unexpected API response: missing 'pages' object")
 	}
 
+	info, found := firstPageInfo(pages, args.Title)
+	if !found {
+		return PageInfo{}, fmt.Errorf("page '%s' not found", normalizedTitle)
+	}
+	if info.Exists {
+		c.setCache(cacheKey, info, "page_info")
+	}
+	return info, nil
+}
+
+// firstPageInfo returns the PageInfo for the first valid page object in the
+// response map. found is false when no usable page object is present. A page
+// flagged missing yields a non-existent PageInfo carrying the requested title.
+func firstPageInfo(pages map[string]interface{}, requestedTitle string) (info PageInfo, found bool) {
 	for _, pageData := range pages {
 		page, ok := pageData.(map[string]interface{})
 		if !ok {
 			continue
 		}
-
-		// Check if page exists
 		if _, missing := page["missing"]; missing {
-			return PageInfo{
-				Title:  args.Title,
-				Exists: false,
-			}, nil
+			return PageInfo{Title: requestedTitle, Exists: false}, true
 		}
+		return buildDetailedPageInfo(page), true
+	}
+	return PageInfo{}, false
+}
 
-		info := PageInfo{
-			Title:        getString(page["title"]),
-			PageID:       getInt(page["pageid"]),
-			Namespace:    getInt(page["ns"]),
-			ContentModel: getString(page["contentmodel"]),
-			PageLanguage: getString(page["pagelanguage"]),
-			Length:       getInt(page["length"]),
-			Touched:      getString(page["touched"]),
-			LastRevision: getInt(page["lastrevid"]),
-			Exists:       true,
-		}
-
-		// Categories
-		if cats, ok := page["categories"].([]interface{}); ok {
-			for _, cat := range cats {
-				c, ok := cat.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				info.Categories = append(info.Categories, getString(c["title"]))
-			}
-		}
-
-		// Links count
-		if links, ok := page["links"].([]interface{}); ok {
-			info.Links = len(links)
-		}
-
-		// Redirect
-		if _, isRedirect := page["redirect"]; isRedirect {
-			info.Redirect = true
-		}
-
-		// Protection
-		if protection, ok := page["protection"].([]interface{}); ok {
-			for _, p := range protection {
-				prot, ok := p.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				info.Protection = append(info.Protection, fmt.Sprintf("%s: %s", prot["type"], prot["level"]))
-			}
-		}
-
-		// Cache the result
-		c.setCache(cacheKey, info, "page_info")
-
-		return info, nil
+// buildDetailedPageInfo converts an existing page's metadata object into a
+// PageInfo, including categories, link count, redirect flag, and protection.
+func buildDetailedPageInfo(page map[string]interface{}) PageInfo {
+	info := PageInfo{
+		Title:        getString(page["title"]),
+		PageID:       getInt(page["pageid"]),
+		Namespace:    getInt(page["ns"]),
+		ContentModel: getString(page["contentmodel"]),
+		PageLanguage: getString(page["pagelanguage"]),
+		Length:       getInt(page["length"]),
+		Touched:      getString(page["touched"]),
+		LastRevision: getInt(page["lastrevid"]),
+		Exists:       true,
 	}
 
-	return PageInfo{}, fmt.Errorf("page '%s' not found", normalizedTitle)
+	info.Categories = extractCategoryTitles(page["categories"])
+	if links, ok := page["links"].([]interface{}); ok {
+		info.Links = len(links)
+	}
+	if _, isRedirect := page["redirect"]; isRedirect {
+		info.Redirect = true
+	}
+	info.Protection = extractProtectionEntries(page["protection"])
+	return info
 }
 
 // GetWikiInfo gets information about the wiki
@@ -322,46 +320,51 @@ func (c *Client) ResolveTitle(ctx context.Context, args ResolveTitleArgs) (Resol
 		return ResolveTitleResult{}, fmt.Errorf("search failed: %w", err)
 	}
 
-	// Calculate similarity and rank results
-	titleLower := strings.ToLower(args.Title)
-	for _, hit := range searchResult.Results {
-		hitLower := strings.ToLower(hit.Title)
+	result.Suggestions = rankTitleSuggestions(args.Title, searchResult.Results)
+	if len(result.Suggestions) > maxResults {
+		result.Suggestions = result.Suggestions[:maxResults]
+	}
+	applyResolveMessage(args.Title, &result)
+	return result, nil
+}
 
-		// Calculate simple similarity score
-		similarity := calculateSimilarity(titleLower, hitLower)
-
-		result.Suggestions = append(result.Suggestions, TitleSuggestion{
+// rankTitleSuggestions scores each search hit against the query title and
+// returns suggestions sorted by descending similarity.
+func rankTitleSuggestions(title string, hits []SearchHit) []TitleSuggestion {
+	titleLower := strings.ToLower(title)
+	suggestions := make([]TitleSuggestion, 0, len(hits))
+	for _, hit := range hits {
+		suggestions = append(suggestions, TitleSuggestion{
 			Title:      hit.Title,
 			PageID:     hit.PageID,
-			Similarity: similarity,
+			Similarity: calculateSimilarity(titleLower, strings.ToLower(hit.Title)),
 		})
 	}
 
 	// Sort by similarity (descending)
-	for i := 0; i < len(result.Suggestions)-1; i++ {
-		for j := i + 1; j < len(result.Suggestions); j++ {
-			if result.Suggestions[j].Similarity > result.Suggestions[i].Similarity {
-				result.Suggestions[i], result.Suggestions[j] = result.Suggestions[j], result.Suggestions[i]
+	for i := 0; i < len(suggestions)-1; i++ {
+		for j := i + 1; j < len(suggestions); j++ {
+			if suggestions[j].Similarity > suggestions[i].Similarity {
+				suggestions[i], suggestions[j] = suggestions[j], suggestions[i]
 			}
 		}
 	}
+	return suggestions
+}
 
-	// Limit results
-	if len(result.Suggestions) > maxResults {
-		result.Suggestions = result.Suggestions[:maxResults]
-	}
-
-	if len(result.Suggestions) > 0 && result.Suggestions[0].Similarity > 0.8 {
+// applyResolveMessage sets ResolvedTitle/PageID/Message based on the best
+// suggestion's similarity.
+func applyResolveMessage(title string, result *ResolveTitleResult) {
+	switch {
+	case len(result.Suggestions) > 0 && result.Suggestions[0].Similarity > 0.8:
 		result.ResolvedTitle = result.Suggestions[0].Title
 		result.PageID = result.Suggestions[0].PageID
 		result.Message = fmt.Sprintf("Did you mean '%s'?", result.Suggestions[0].Title)
-	} else if len(result.Suggestions) > 0 {
-		result.Message = fmt.Sprintf("Page '%s' not found. Similar pages found.", args.Title)
-	} else {
-		result.Message = fmt.Sprintf("Page '%s' not found. No similar pages.", args.Title)
+	case len(result.Suggestions) > 0:
+		result.Message = fmt.Sprintf("Page '%s' not found. Similar pages found.", title)
+	default:
+		result.Message = fmt.Sprintf("Page '%s' not found. No similar pages.", title)
 	}
-
-	return result, nil
 }
 
 // calculateSimilarity calculates string similarity (Jaccard-like)

--- a/wiki/quality_terminology.go
+++ b/wiki/quality_terminology.go
@@ -37,27 +37,37 @@ func (c *Client) CheckTerminology(ctx context.Context, args CheckTerminologyArgs
 		Pages:        make([]PageTerminologyResult, 0, len(pagesToCheck)),
 	}
 
-	// Determine if code blocks should be excluded (default: true)
-	excludeCode := true
-	if args.ExcludeCodeBlocks != nil {
-		excludeCode = *args.ExcludeCodeBlocks
+	excludeCode := excludeCodeBlocks(args.ExcludeCodeBlocks)
+	if err := c.checkPagesTerminology(ctx, pagesToCheck, glossary, excludeCode, &result); err != nil {
+		return result, err
 	}
 
-	// Check each page
-	for _, pageTitle := range pagesToCheck {
-		// Check for context cancellation
+	result.PagesChecked = len(result.Pages)
+	return result, nil
+}
+
+// excludeCodeBlocks resolves the exclude-code-blocks flag, defaulting to true.
+func excludeCodeBlocks(flag *bool) bool {
+	if flag != nil {
+		return *flag
+	}
+	return true
+}
+
+// checkPagesTerminology checks each page against the glossary, accumulating
+// results. It aborts early on context cancellation.
+func (c *Client) checkPagesTerminology(ctx context.Context, pages []string, glossary []GlossaryTerm, excludeCode bool, result *CheckTerminologyResult) error {
+	for _, pageTitle := range pages {
 		select {
 		case <-ctx.Done():
-			return result, ctx.Err()
+			return ctx.Err()
 		default:
 		}
 		pageResult := c.checkPageTerminology(ctx, pageTitle, glossary, excludeCode)
 		result.Pages = append(result.Pages, pageResult)
 		result.IssuesFound += pageResult.IssueCount
 	}
-
-	result.PagesChecked = len(result.Pages)
-	return result, nil
+	return nil
 }
 
 // loadGlossary parses a wiki table to extract glossary terms
@@ -103,14 +113,22 @@ func parseWikiTableGlossary(content string) []GlossaryTerm {
 		if len(table) < 2 {
 			continue
 		}
-		for _, row := range strings.Split(table[1], "|-") {
-			row = strings.TrimSpace(row)
-			if row == "" || strings.HasPrefix(row, "!") {
-				continue
-			}
-			if term, ok := glossaryTermFromCells(parseTableRow(row)); ok {
-				terms = append(terms, term)
-			}
+		terms = append(terms, parseGlossaryTableRows(table[1])...)
+	}
+	return terms
+}
+
+// parseGlossaryTableRows parses the rows of a single glossary table body into
+// glossary terms.
+func parseGlossaryTableRows(tableBody string) []GlossaryTerm {
+	var terms []GlossaryTerm
+	for _, row := range strings.Split(tableBody, "|-") {
+		row = strings.TrimSpace(row)
+		if row == "" || strings.HasPrefix(row, "!") {
+			continue
+		}
+		if term, ok := glossaryTermFromCells(parseTableRow(row)); ok {
+			terms = append(terms, term)
 		}
 	}
 	return terms
@@ -119,27 +137,25 @@ func parseWikiTableGlossary(content string) []GlossaryTerm {
 // parseTableRow extracts cells from a wiki table row
 func parseTableRow(row string) []string {
 	var cells []string
-	lines := strings.Split(row, "\n")
-
-	for _, line := range lines {
+	for _, line := range strings.Split(row, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "!") {
 			continue
 		}
+		cells = append(cells, parseRowLineCells(line)...)
+	}
+	return cells
+}
 
-		// Remove leading | if present
-		line = strings.TrimPrefix(line, "|")
-
-		// Split by || for multiple cells on one line
-		parts := strings.Split(line, "||")
-		for _, part := range parts {
-			cell := strings.TrimSpace(part)
-			if cell != "" {
-				cells = append(cells, cell)
-			}
+// parseRowLineCells splits one table-row line into trimmed, non-empty cells.
+func parseRowLineCells(line string) []string {
+	var cells []string
+	// Remove leading | if present, then split by || for multiple cells.
+	for _, part := range strings.Split(strings.TrimPrefix(line, "|"), "||") {
+		if cell := strings.TrimSpace(part); cell != "" {
+			cells = append(cells, cell)
 		}
 	}
-
 	return cells
 }
 

--- a/wiki/read.go
+++ b/wiki/read.go
@@ -89,79 +89,85 @@ func (c *Client) getPageWikitext(ctx context.Context, title string) (PageContent
 		if !ok {
 			continue
 		}
-
-		// Check if page exists
-		if _, missing := page["missing"]; missing {
-			// Try to suggest similar pages
-			return PageContent{}, fmt.Errorf("page '%s' does not exist. Try using mediawiki_resolve_title to find the correct page name", title)
-		}
-
-		revisions, ok := page["revisions"].([]interface{})
-		if !ok || len(revisions) == 0 {
-			return PageContent{}, fmt.Errorf("no revisions found for page '%s'. The page may be empty or protected", title)
-		}
-
-		rev, ok := revisions[0].(map[string]interface{})
-		if !ok {
-			return PageContent{}, fmt.Errorf("invalid revision data for page '%s'", title)
-		}
-
-		slots, ok := rev["slots"].(map[string]interface{})
-		if !ok {
-			return PageContent{}, fmt.Errorf("invalid slots data for page '%s'. This may be a MediaWiki version compatibility issue", title)
-		}
-
-		main, ok := slots["main"].(map[string]interface{})
-		if !ok {
-			return PageContent{}, fmt.Errorf("invalid main slot data for page '%s'", title)
-		}
-
-		// MediaWiki API returns content under "*" key, not "content"
-		content, ok := main["*"].(string)
-		if !ok {
-			// Some versions might use "content" instead
-			content, ok = main["content"].(string)
-			if !ok {
-				return PageContent{}, fmt.Errorf("page '%s' has no content or content is not text", title)
-			}
-		}
-
-		truncated := false
-		if len(content) > CharacterLimit {
-			content, truncated = truncateContent(content, CharacterLimit)
-		}
-
-		id, _ := strconv.Atoi(pageID)
-		pageTitle, _ := page["title"].(string)
-		if pageTitle == "" {
-			pageTitle = title
-		}
-
-		revID := 0
-		if rid, ok := rev["revid"].(float64); ok {
-			revID = int(rid)
-		}
-
-		timestamp, _ := rev["timestamp"].(string)
-
-		result := PageContent{
-			Title:     pageTitle,
-			PageID:    id,
-			Content:   content,
-			Format:    "wikitext",
-			Revision:  revID,
-			Timestamp: timestamp,
-			Truncated: truncated,
-		}
-
-		if truncated {
-			result.Message = "Content was truncated due to size limits. Consider fetching specific sections."
-		}
-
-		return result, nil
+		return buildWikitextPageContent(page, pageID, title)
 	}
 
 	return PageContent{}, fmt.Errorf("page '%s' not found in API response", title)
+}
+
+// buildWikitextPageContent converts a single wikitext page object into a
+// PageContent, returning descriptive errors for each response-shape failure.
+func buildWikitextPageContent(page map[string]interface{}, pageID, title string) (PageContent, error) {
+	if _, missing := page["missing"]; missing {
+		return PageContent{}, fmt.Errorf("page '%s' does not exist. Try using mediawiki_resolve_title to find the correct page name", title)
+	}
+
+	content, rev, err := extractWikitextRevision(page, title)
+	if err != nil {
+		return PageContent{}, err
+	}
+
+	truncated := false
+	if len(content) > CharacterLimit {
+		content, truncated = truncateContent(content, CharacterLimit)
+	}
+
+	id, _ := strconv.Atoi(pageID)
+	pageTitle, _ := page["title"].(string)
+	if pageTitle == "" {
+		pageTitle = title
+	}
+	revID := 0
+	if rid, ok := rev["revid"].(float64); ok {
+		revID = int(rid)
+	}
+	timestamp, _ := rev["timestamp"].(string)
+
+	result := PageContent{
+		Title:     pageTitle,
+		PageID:    id,
+		Content:   content,
+		Format:    "wikitext",
+		Revision:  revID,
+		Timestamp: timestamp,
+		Truncated: truncated,
+	}
+	if truncated {
+		result.Message = "Content was truncated due to size limits. Consider fetching specific sections."
+	}
+	return result, nil
+}
+
+// extractWikitextRevision walks revisions[0].slots.main and returns the content
+// string and the revision map, with descriptive errors for each shape failure.
+func extractWikitextRevision(page map[string]interface{}, title string) (content string, rev map[string]interface{}, err error) {
+	revisions, ok := page["revisions"].([]interface{})
+	if !ok || len(revisions) == 0 {
+		return "", nil, fmt.Errorf("no revisions found for page '%s'. The page may be empty or protected", title)
+	}
+	rev, ok = revisions[0].(map[string]interface{})
+	if !ok {
+		return "", nil, fmt.Errorf("invalid revision data for page '%s'", title)
+	}
+	slots, ok := rev["slots"].(map[string]interface{})
+	if !ok {
+		return "", nil, fmt.Errorf("invalid slots data for page '%s'. This may be a MediaWiki version compatibility issue", title)
+	}
+	main, ok := slots["main"].(map[string]interface{})
+	if !ok {
+		return "", nil, fmt.Errorf("invalid main slot data for page '%s'", title)
+	}
+
+	// MediaWiki API returns content under "*" key, not "content"; some versions
+	// use "content" instead.
+	content, ok = main["*"].(string)
+	if !ok {
+		content, ok = main["content"].(string)
+		if !ok {
+			return "", nil, fmt.Errorf("page '%s' has no content or content is not text", title)
+		}
+	}
+	return content, rev, nil
 }
 
 func (c *Client) getPageHTML(ctx context.Context, title string) (PageContent, error) {
@@ -203,35 +209,35 @@ func (c *Client) getPageHTML(ctx context.Context, title string) (PageContent, er
 		content, truncated = truncateContent(content, CharacterLimit)
 	}
 
-	pageTitle, _ := parse["title"].(string)
-	if pageTitle == "" {
-		pageTitle = title
-	}
-
-	pageID := 0
-	if pid, ok := parse["pageid"].(float64); ok {
-		pageID = int(pid)
-	}
-
-	revID := 0
-	if rid, ok := parse["revid"].(float64); ok {
-		revID = int(rid)
-	}
-
 	result := PageContent{
-		Title:     pageTitle,
-		PageID:    pageID,
+		Title:     htmlPageTitle(parse, title),
+		PageID:    intField(parse, "pageid"),
 		Content:   content,
 		Format:    "html",
-		Revision:  revID,
+		Revision:  intField(parse, "revid"),
 		Truncated: truncated,
 	}
-
 	if truncated {
 		result.Message = "Content was truncated due to size limits."
 	}
-
 	return result, nil
+}
+
+// htmlPageTitle returns the parse response's title, falling back to the
+// requested title.
+func htmlPageTitle(parse map[string]interface{}, fallback string) string {
+	if t, _ := parse["title"].(string); t != "" {
+		return t
+	}
+	return fallback
+}
+
+// intField reads a float64-encoded JSON number field as an int (0 if absent).
+func intField(m map[string]interface{}, key string) int {
+	if v, ok := m[key].(float64); ok {
+		return int(v)
+	}
+	return 0
 }
 
 // Parse parses wikitext and returns HTML
@@ -279,37 +285,31 @@ func (c *Client) Parse(ctx context.Context, args ParseArgs) (ParseResult, error)
 	}
 
 	result := ParseResult{
-		HTML:      htmlContent,
-		Truncated: truncated,
+		HTML:       htmlContent,
+		Truncated:  truncated,
+		Categories: extractStarValues(parse["categories"]),
+		Links:      extractStarValues(parse["links"]),
 	}
-
-	// Categories
-	if cats, ok := parse["categories"].([]interface{}); ok {
-		for _, cat := range cats {
-			c, ok := cat.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			result.Categories = append(result.Categories, getString(c["*"]))
-		}
-	}
-
-	// Links
-	if links, ok := parse["links"].([]interface{}); ok {
-		for _, link := range links {
-			l, ok := link.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			result.Links = append(result.Links, getString(l["*"]))
-		}
-	}
-
 	if truncated {
 		result.Message = "Content was truncated due to size limits."
 	}
-
 	return result, nil
+}
+
+// extractStarValues pulls the "*" string field from each map entry in a
+// MediaWiki list (used for categories and links in parse responses).
+func extractStarValues(raw interface{}) []string {
+	entries, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	var values []string
+	for _, e := range entries {
+		if m, ok := e.(map[string]interface{}); ok {
+			values = append(values, getString(m["*"]))
+		}
+	}
+	return values
 }
 
 // GetPageSummary returns the lead section and key metadata for a page.

--- a/wiki/similarity.go
+++ b/wiki/similarity.go
@@ -193,51 +193,63 @@ func findCommonTerms(termsA, termsB []string, limit int) []string {
 
 // extractContextsForTerm extracts lines containing the search term
 func extractContextsForTerm(content, term string, maxContexts int) []string {
-	lines := strings.Split(content, "\n")
 	termLower := strings.ToLower(term)
 	contexts := make([]string, 0)
 
-	for _, line := range lines {
-		if strings.Contains(strings.ToLower(line), termLower) {
-			// Clean up the line
-			cleaned := strings.TrimSpace(line)
-			if cleaned != "" && len(cleaned) > 10 {
-				// Truncate long lines
-				if len(cleaned) > 200 {
-					cleaned = cleaned[:200] + "..."
-				}
-				contexts = append(contexts, cleaned)
-				if maxContexts > 0 && len(contexts) >= maxContexts {
-					break
-				}
-			}
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.Contains(strings.ToLower(line), termLower) {
+			continue
+		}
+		cleaned, ok := cleanContextLine(line)
+		if !ok {
+			continue
+		}
+		contexts = append(contexts, cleaned)
+		if maxContexts > 0 && len(contexts) >= maxContexts {
+			break
 		}
 	}
 
 	return contexts
 }
 
-// extractTopTerms gets the most frequent significant terms
-func extractTopTerms(content string, limit int) []string {
-	// Remove wiki markup
-	plainText := removeWikiMarkup(content)
-	plainText = strings.ToLower(plainText)
+// cleanContextLine trims a context line and truncates it to 200 chars. ok is
+// false for blank or too-short (<= 10 chars) lines, which are skipped.
+func cleanContextLine(line string) (string, bool) {
+	cleaned := strings.TrimSpace(line)
+	if cleaned == "" || len(cleaned) <= 10 {
+		return "", false
+	}
+	if len(cleaned) > 200 {
+		cleaned = cleaned[:200] + "..."
+	}
+	return cleaned, true
+}
 
-	// Tokenize
-	words := strings.FieldsFunc(plainText, func(r rune) bool {
+// isSignificantTerm reports whether a token should count toward term
+// frequency: at least 3 chars, not a stopword, and not purely numeric.
+func isSignificantTerm(word string) bool {
+	return len(word) >= 3 && !stopwords[word] && !isNumeric(word)
+}
+
+// tokenizePlainText lowercases content, strips wiki markup, and splits into
+// word/digit tokens.
+func tokenizePlainText(content string) []string {
+	plainText := strings.ToLower(removeWikiMarkup(content))
+	return strings.FieldsFunc(plainText, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
+}
 
-	// Count frequencies
+// extractTopTerms gets the most frequent significant terms
+func extractTopTerms(content string, limit int) []string {
 	freq := make(map[string]int)
-	for _, word := range words {
-		if len(word) < 3 || stopwords[word] || isNumeric(word) {
-			continue
+	for _, word := range tokenizePlainText(content) {
+		if isSignificantTerm(word) {
+			freq[word]++
 		}
-		freq[word]++
 	}
 
-	// Sort by frequency
 	type termFreq struct {
 		term  string
 		count int
@@ -250,7 +262,6 @@ func extractTopTerms(content string, limit int) []string {
 		return ranked[i].count > ranked[j].count
 	})
 
-	// Take top N
 	result := make([]string, 0, limit)
 	for i := 0; i < len(ranked) && i < limit; i++ {
 		result = append(result, ranked[i].term)
@@ -287,23 +298,26 @@ type ExtractedValue struct {
 // extractValues finds typed values in content using patterns
 func extractValues(content string) []ExtractedValue {
 	values := make([]ExtractedValue, 0)
+	for _, line := range strings.Split(content, "\n") {
+		values = append(values, extractValuesFromLine(line)...)
+	}
+	return values
+}
 
-	lines := strings.Split(content, "\n")
-	for _, line := range lines {
-		for _, vp := range valuePatterns {
-			matches := vp.Pattern.FindAllStringSubmatch(line, -1)
-			for _, match := range matches {
-				if len(match) >= 2 {
-					fullMatch := match[0]
-					values = append(values, ExtractedValue{
-						Type:    vp.Name,
-						Value:   fullMatch,
-						Context: strings.TrimSpace(line),
-					})
-				}
+// extractValuesFromLine applies every value pattern to one line.
+func extractValuesFromLine(line string) []ExtractedValue {
+	var values []ExtractedValue
+	trimmed := strings.TrimSpace(line)
+	for _, vp := range valuePatterns {
+		for _, match := range vp.Pattern.FindAllStringSubmatch(line, -1) {
+			if len(match) >= 2 {
+				values = append(values, ExtractedValue{
+					Type:    vp.Name,
+					Value:   match[0],
+					Context: trimmed,
+				})
 			}
 		}
 	}
-
 	return values
 }

--- a/wiki/upload.go
+++ b/wiki/upload.go
@@ -14,11 +14,8 @@ import (
 
 // UploadFile uploads a file to the wiki
 func (c *Client) UploadFile(ctx context.Context, args UploadFileArgs) (UploadFileResult, error) {
-	if args.Filename == "" {
-		return UploadFileResult{}, fmt.Errorf("filename is required")
-	}
-	if args.FilePath == "" && args.FileURL == "" && len(args.FileData) == 0 {
-		return UploadFileResult{}, fmt.Errorf("either file_path, file_url, or file_data is required")
+	if err := validateUploadArgs(args); err != nil {
+		return UploadFileResult{}, err
 	}
 
 	if err := c.EnsureLoggedIn(ctx); err != nil {
@@ -31,41 +28,47 @@ func (c *Client) UploadFile(ctx context.Context, args UploadFileArgs) (UploadFil
 		result, err = c.performUpload(ctx, args)
 	}
 
-	// Log upload attempt (even if error occurred)
-	if err != nil {
-		c.logAudit(AuditEntry{
-			Timestamp:   time.Now().UTC().Format(time.RFC3339),
-			Operation:   AuditOpUpload,
-			Title:       "File:" + args.Filename,
-			ContentHash: hashContent(args.FileURL + args.FilePath + string(args.FileData)), // Hash the source
-			ContentSize: 0,
-			Summary:     args.Comment,
-			WikiURL:     c.config.BaseURL,
-			Success:     false,
-			Error:       err.Error(),
-		})
-		return result, err
-	}
+	c.logUploadOutcome(args, result, err)
+	return result, err
+}
 
-	// Log upload result
-	c.logAudit(AuditEntry{
+// validateUploadArgs enforces required upload inputs.
+func validateUploadArgs(args UploadFileArgs) error {
+	if args.Filename == "" {
+		return fmt.Errorf("filename is required")
+	}
+	if args.FilePath == "" && args.FileURL == "" && len(args.FileData) == 0 {
+		return fmt.Errorf("either file_path, file_url, or file_data is required")
+	}
+	return nil
+}
+
+// logUploadOutcome records an audit entry for an upload attempt, whether it
+// failed (err != nil) or completed (with its own success flag).
+func (c *Client) logUploadOutcome(args UploadFileArgs, result UploadFileResult, err error) {
+	contentHash := hashContent(args.FileURL + args.FilePath + string(args.FileData))
+	entry := AuditEntry{
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
 		Operation:   AuditOpUpload,
-		Title:       "File:" + result.Filename,
-		ContentHash: hashContent(args.FileURL + args.FilePath + string(args.FileData)),
-		ContentSize: result.Size,
+		ContentHash: contentHash,
 		Summary:     args.Comment,
 		WikiURL:     c.config.BaseURL,
-		Success:     result.Success,
-		Error: func() string {
-			if !result.Success {
-				return result.Message
-			}
-			return ""
-		}(),
-	})
+	}
+	if err != nil {
+		entry.Title = "File:" + args.Filename
+		entry.Success = false
+		entry.Error = err.Error()
+		c.logAudit(entry)
+		return
+	}
 
-	return result, nil
+	entry.Title = "File:" + result.Filename
+	entry.ContentSize = result.Size
+	entry.Success = result.Success
+	if !result.Success {
+		entry.Error = result.Message
+	}
+	c.logAudit(entry)
 }
 
 // performUpload executes a single upload attempt with a fresh CSRF token.
@@ -248,29 +251,38 @@ func (c *Client) parseUploadResponse(resp map[string]interface{}, filename strin
 		Filename: filename,
 	}
 
-	status := getString(upload["result"])
-	switch status {
+	switch status := getString(upload["result"]); status {
 	case "Success":
-		result.Success = true
-		result.Message = "File uploaded successfully"
-		if imageinfo, ok := upload["imageinfo"].(map[string]interface{}); ok {
-			result.URL = getString(imageinfo["url"])
-			result.Size = getInt(imageinfo["size"])
-		}
+		applyUploadSuccess(upload, &result)
 	case "Warning":
-		result.Success = false
-		result.Message = "Upload has warnings - set ignore_warnings=true to proceed"
-		if warnings, ok := upload["warnings"].(map[string]interface{}); ok {
-			for k, v := range warnings {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("%s: %v", k, v))
-			}
-		}
+		applyUploadWarning(upload, &result)
 	default:
 		result.Success = false
 		result.Message = fmt.Sprintf("Upload status: %s", status)
 	}
 
 	return result, nil
+}
+
+// applyUploadSuccess fills a successful upload result, including image metadata.
+func applyUploadSuccess(upload map[string]interface{}, result *UploadFileResult) {
+	result.Success = true
+	result.Message = "File uploaded successfully"
+	if imageinfo, ok := upload["imageinfo"].(map[string]interface{}); ok {
+		result.URL = getString(imageinfo["url"])
+		result.Size = getInt(imageinfo["size"])
+	}
+}
+
+// applyUploadWarning fills a warning upload result with the reported warnings.
+func applyUploadWarning(upload map[string]interface{}, result *UploadFileResult) {
+	result.Success = false
+	result.Message = "Upload has warnings - set ignore_warnings=true to proceed"
+	if warnings, ok := upload["warnings"].(map[string]interface{}); ok {
+		for k, v := range warnings {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("%s: %v", k, v))
+		}
+	}
 }
 
 // parseJSONResponse decodes an *http.Response body as JSON into target.

--- a/wiki/write.go
+++ b/wiki/write.go
@@ -10,38 +10,7 @@ import (
 
 // EditPage creates or edits a page
 func (c *Client) EditPage(ctx context.Context, args EditPageArgs) (EditResult, error) {
-	if args.Title == "" {
-		return EditResult{}, &ValidationError{
-			Field:   "title",
-			Message: "page title is required",
-			Suggestion: `Provide a title for the page you want to edit.
-
-Example:
-  Title: "My Page"
-  Title: "Category:My Category"
-  Title: "User:Username/Subpage"`,
-		}
-	}
-	if args.Content == "" {
-		return EditResult{}, &ValidationError{
-			Field:   "content",
-			Message: "page content is required",
-			Suggestion: `Provide the wikitext content for the page.
-
-Example:
-  Content: "== Section ==\nThis is the page content."
-
-If you want to clear a page, use a single space or redirect instead.`,
-		}
-	}
-
-	// Validate content size
-	if err := ValidateContentSize(args.Content, args.Title, MaxEditSize); err != nil {
-		return EditResult{}, err
-	}
-
-	// Validate content for dangerous patterns
-	if err := ValidateWikitextContent(args.Content, args.Title); err != nil {
+	if err := validateEditArgs(args); err != nil {
 		return EditResult{}, err
 	}
 
@@ -54,6 +23,38 @@ If you want to clear a page, use a single space or redirect instead.`,
 		return EditResult{}, err
 	}
 	return editResult, nil
+}
+
+// validateEditArgs checks required fields and content safety for an edit.
+func validateEditArgs(args EditPageArgs) error {
+	if args.Title == "" {
+		return &ValidationError{
+			Field:   "title",
+			Message: "page title is required",
+			Suggestion: `Provide a title for the page you want to edit.
+
+Example:
+  Title: "My Page"
+  Title: "Category:My Category"
+  Title: "User:Username/Subpage"`,
+		}
+	}
+	if args.Content == "" {
+		return &ValidationError{
+			Field:   "content",
+			Message: "page content is required",
+			Suggestion: `Provide the wikitext content for the page.
+
+Example:
+  Content: "== Section ==\nThis is the page content."
+
+If you want to clear a page, use a single space or redirect instead.`,
+		}
+	}
+	if err := ValidateContentSize(args.Content, args.Title, MaxEditSize); err != nil {
+		return err
+	}
+	return ValidateWikitextContent(args.Content, args.Title)
 }
 
 // performEdit executes a single edit attempt with a fresh CSRF token.
@@ -121,29 +122,7 @@ func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult
 	}
 
 	if status := getString(edit["result"]); status != "Success" {
-		msg := fmt.Sprintf("Edit failed: %s", status)
-		if info := getString(edit["info"]); info != "" {
-			msg += fmt.Sprintf(" - %s", info)
-		}
-		var captchaType, captchaID, captchaQuestion string
-		if captcha := getMap(edit["captcha"]); captcha != nil {
-			captchaType = getString(captcha["type"])
-			captchaID = getString(captcha["id"])
-			captchaQuestion = getString(captcha["question"])
-			msg += fmt.Sprintf(" (CAPTCHA: %s)", captchaType)
-		}
-		c.logAudit(c.buildAuditEntry(
-			AuditOpEdit, args.Title, args.Content, args.Summary,
-			args.Minor, args.Bot, false, 0, 0, msg,
-		))
-		return EditResult{
-			Success:         false,
-			Title:           args.Title,
-			Message:         msg,
-			CaptchaType:     captchaType,
-			CaptchaID:       captchaID,
-			CaptchaQuestion: captchaQuestion,
-		}, nil
+		return c.failedEditResult(args, edit, status), nil
 	}
 
 	editResult := editResultFromAPI(edit)
@@ -156,6 +135,34 @@ func (c *Client) performEdit(ctx context.Context, args EditPageArgs) (EditResult
 		args.Minor, args.Bot, true, editResult.PageID, editResult.RevisionID, "",
 	))
 	return editResult, nil
+}
+
+// failedEditResult builds the EditResult (and audit entry) for a non-Success
+// edit API response, including any CAPTCHA challenge details.
+func (c *Client) failedEditResult(args EditPageArgs, edit map[string]interface{}, status string) EditResult {
+	msg := fmt.Sprintf("Edit failed: %s", status)
+	if info := getString(edit["info"]); info != "" {
+		msg += fmt.Sprintf(" - %s", info)
+	}
+	var captchaType, captchaID, captchaQuestion string
+	if captcha := getMap(edit["captcha"]); captcha != nil {
+		captchaType = getString(captcha["type"])
+		captchaID = getString(captcha["id"])
+		captchaQuestion = getString(captcha["question"])
+		msg += fmt.Sprintf(" (CAPTCHA: %s)", captchaType)
+	}
+	c.logAudit(c.buildAuditEntry(
+		AuditOpEdit, args.Title, args.Content, args.Summary,
+		args.Minor, args.Bot, false, 0, 0, msg,
+	))
+	return EditResult{
+		Success:         false,
+		Title:           args.Title,
+		Message:         msg,
+		CaptchaType:     captchaType,
+		CaptchaID:       captchaID,
+		CaptchaQuestion: captchaQuestion,
+	}
 }
 
 // FindReplace finds and replaces text in a wiki page
@@ -202,26 +209,7 @@ func applyFindReplaceToLine(line string, lineNum int, op findReplaceOp, replacem
 		return out
 	}
 
-	var newLine string
-	var replaceCount int
-	if op.all {
-		newLine = op.re.ReplaceAllString(line, op.replace)
-		if newLine != line {
-			replaceCount = len(matches)
-		}
-	} else {
-		replaced := false
-		newLine = op.re.ReplaceAllStringFunc(line, func(match string) string {
-			if !replaced {
-				replaced = true
-				return op.replace
-			}
-			return match
-		})
-		if replaced {
-			replaceCount = 1
-		}
-	}
+	newLine, replaceCount := op.rewriteLine(line, len(matches))
 	if newLine == line {
 		return out
 	}
@@ -234,6 +222,32 @@ func applyFindReplaceToLine(line string, lineNum int, op findReplaceOp, replacem
 		Context: extractContext(line, matches[0][0], matches[0][1], 40),
 	}
 	return out
+}
+
+// rewriteLine performs the replacement on a line and reports how many
+// occurrences were replaced. In all-mode every match is replaced; otherwise
+// only the first match is.
+func (op findReplaceOp) rewriteLine(line string, matchCount int) (newLine string, replaceCount int) {
+	if op.all {
+		newLine = op.re.ReplaceAllString(line, op.replace)
+		if newLine != line {
+			replaceCount = matchCount
+		}
+		return newLine, replaceCount
+	}
+
+	replaced := false
+	newLine = op.re.ReplaceAllStringFunc(line, func(match string) string {
+		if !replaced {
+			replaced = true
+			return op.replace
+		}
+		return match
+	})
+	if replaced {
+		replaceCount = 1
+	}
+	return newLine, replaceCount
 }
 
 // applyFindReplaceToContent runs the line-by-line replacement on the page content.
@@ -252,19 +266,27 @@ func applyFindReplaceToContent(content string, op findReplaceOp) (newContent str
 	return strings.Join(newLines, "\n"), changes, matchCount, replaceCount
 }
 
+// findReplaceSaveInput bundles everything saveFindReplaceEdit needs to write a
+// find/replace edit back to the wiki.
+type findReplaceSaveInput struct {
+	page       PageContent
+	newContent string
+	args       FindReplaceArgs
+}
+
 // saveFindReplaceEdit writes the rewritten content back to the wiki and records
 // the resulting revision metadata on the result.
-func (c *Client) saveFindReplaceEdit(ctx context.Context, page PageContent, newContent string, args FindReplaceArgs, result *FindReplaceResult) error {
-	summary := args.Summary
+func (c *Client) saveFindReplaceEdit(ctx context.Context, in findReplaceSaveInput, result *FindReplaceResult) error {
+	summary := in.args.Summary
 	if summary == "" {
-		summary = fmt.Sprintf("Replaced '%s' with '%s'", truncateString(args.Find, 30), truncateString(args.Replace, 30))
+		summary = fmt.Sprintf("Replaced '%s' with '%s'", truncateString(in.args.Find, 30), truncateString(in.args.Replace, 30))
 	}
-	oldRevision := page.Revision
+	oldRevision := in.page.Revision
 	editResult, err := c.EditPage(ctx, EditPageArgs{
-		Title:   page.Title,
-		Content: newContent,
+		Title:   in.page.Title,
+		Content: in.newContent,
 		Summary: summary,
-		Minor:   args.Minor,
+		Minor:   in.args.Minor,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to save changes: %w", err)
@@ -272,7 +294,7 @@ func (c *Client) saveFindReplaceEdit(ctx context.Context, page PageContent, newC
 	result.Success = editResult.Success
 	result.RevisionID = editResult.RevisionID
 	result.Message = fmt.Sprintf("Replaced %d occurrence(s)", result.ReplaceCount)
-	result.Revision, result.Undo = c.buildEditRevisionInfo(page.Title, oldRevision, editResult.RevisionID)
+	result.Revision, result.Undo = c.buildEditRevisionInfo(in.page.Title, oldRevision, editResult.RevisionID)
 	return nil
 }
 
@@ -314,7 +336,7 @@ func (c *Client) FindReplace(ctx context.Context, args FindReplaceArgs) (FindRep
 		return result, nil
 	}
 
-	if err := c.saveFindReplaceEdit(ctx, page, newContent, args, &result); err != nil {
+	if err := c.saveFindReplaceEdit(ctx, findReplaceSaveInput{page: page, newContent: newContent, args: args}, &result); err != nil {
 		return FindReplaceResult{}, err
 	}
 	return result, nil
@@ -436,23 +458,30 @@ func (c *Client) BulkReplace(ctx context.Context, args BulkReplaceArgs) (BulkRep
 		Preview: args.Preview,
 		Results: make([]PageReplaceResult, 0, len(pagesToProcess)),
 	}
-
 	for _, pageTitle := range pagesToProcess {
-		pageResult := c.processBulkReplacePage(ctx, pageTitle, args, summary)
-		if pageResult.Error == "" && pageResult.ReplaceCount > 0 {
-			result.PagesModified++
-			result.TotalChanges += pageResult.ReplaceCount
-		}
-		result.Results = append(result.Results, pageResult)
+		result.add(c.processBulkReplacePage(ctx, pageTitle, args, summary))
 	}
 
 	result.PagesProcessed = len(result.Results)
-	if args.Preview {
-		result.Message = fmt.Sprintf("Preview: %d pages would be modified with %d total changes", result.PagesModified, result.TotalChanges)
-	} else {
-		result.Message = fmt.Sprintf("Modified %d pages with %d total changes", result.PagesModified, result.TotalChanges)
-	}
+	result.Message = bulkReplaceMessage(args.Preview, result.PagesModified, result.TotalChanges)
 	return result, nil
+}
+
+// add records one page result, updating modified/total counters.
+func (r *BulkReplaceResult) add(pageResult PageReplaceResult) {
+	if pageResult.Error == "" && pageResult.ReplaceCount > 0 {
+		r.PagesModified++
+		r.TotalChanges += pageResult.ReplaceCount
+	}
+	r.Results = append(r.Results, pageResult)
+}
+
+// bulkReplaceMessage renders the preview/applied summary line.
+func bulkReplaceMessage(preview bool, pagesModified, totalChanges int) string {
+	if preview {
+		return fmt.Sprintf("Preview: %d pages would be modified with %d total changes", pagesModified, totalChanges)
+	}
+	return fmt.Sprintf("Modified %d pages with %d total changes", pagesModified, totalChanges)
 }
 
 // truncateString truncates a string for display


### PR DESCRIPTION
## CodeScene Code Health refactor

13 files raised to 9.0-10.0 (evals/runner.go 7.49->10.0, wiki/batch.go 8.33->10.0, etc.). tools/definitions_write.go is a data file with no scoreable functions (left as-is).

Behavior-preserving: no exported names, tool/operation names, CLI flags, or output shapes changed; build/lint/test gates pass. Part of a portfolio-wide CodeScene sweep lifting all source files to Green (Code Health >= 9.0), 21-06-2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)