### PR TITLE
fix: inject ServerVersion from git tag at build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          go build -ldflags="-s -w" -o mediawiki-mcp-server-${{ matrix.suffix }}${{ matrix.ext }} .
+          go build -ldflags="-s -w -X main.ServerVersion=${GITHUB_REF_NAME#v}" -o mediawiki-mcp-server-${{ matrix.suffix }}${{ matrix.ext }} .
 
       - name: Build wiki CLI
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to MediaWiki MCP Server are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **Reported server version no longer drifts from the release tag.** `ServerVersion` was a hand-maintained constant stuck at `1.28.1` through the 1.29–1.32 releases, so the value surfaced in MCP server registration, the `/health` and `/status` endpoints, and startup logs was wrong. It is now a build-time variable injected from the git tag via `-ldflags "-X main.ServerVersion=<version>"` (release workflow and Makefile), defaulting to `dev` for plain `go build`.
+
 ## [1.32.0] - 2026-06-25
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINARY_NAME=mediawiki-mcp-server
 BINARY_NAME_WIKI=wiki-cli
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
-LDFLAGS=-ldflags "-w -s -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)"
+LDFLAGS=-ldflags "-w -s -X main.Version=$(VERSION) -X main.ServerVersion=$(VERSION) -X main.BuildTime=$(BUILD_TIME)"
 
 # Go parameters
 GOCMD=go

--- a/main.go
+++ b/main.go
@@ -30,10 +30,14 @@ func recoverPanic(logger *slog.Logger, operation string) {
 	}
 }
 
-const (
-	ServerName    = "mediawiki-mcp-server"
-	ServerVersion = "1.28.1"
-)
+const ServerName = "mediawiki-mcp-server"
+
+// ServerVersion is injected at build time via
+// -ldflags "-X main.ServerVersion=<version>" (see .github/workflows/release.yml
+// and the Makefile). It defaults to "dev" for a plain `go build`, so the value
+// can never silently drift from the git tag the way the old hand-maintained
+// constant did (it was stuck at 1.28.1 through the 1.29–1.31 releases).
+var ServerVersion = "dev"
 
 // serverInstructions is the tool-selection guide handed to MCP clients on
 // connect. Kept as a top-level constant so main() stays small.


### PR DESCRIPTION
## Problem

`ServerVersion` was a hand-maintained constant (`main.go`) stuck at `1.28.1` through the 1.29–1.32 releases. That stale value was surfaced to users in:
- MCP server registration (`Version:` handed to clients)
- the `/health` and `/status` HTTP endpoints
- startup logs and the tracing `ServiceVersion`

## Fix

Make `ServerVersion` a build-time variable injected from the git tag:
- `var ServerVersion = "dev"` — fallback for plain `go build`
- `release.yml` injects `-X main.ServerVersion=${GITHUB_REF_NAME#v}` (tag minus the leading `v`)
- `Makefile` LDFLAGS adds `-X main.ServerVersion=$(VERSION)` (`git describe`)

It can no longer silently drift from the tag.

## Verification

- ldflags injection confirmed (`strings` on the built binary shows the injected value); plain build falls back to `dev`
- `go vet` clean, `golangci-lint` 0 issues, root-package tests pass
- CodeScene `main.go` = 9.92 (green)
- No test referenced the old constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)