### PR TITLE
Agent-friendly wiki CLI: fix exit codes, add --version, guard edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          go build -ldflags="-s -w" -o wiki-${{ matrix.suffix }}${{ matrix.ext }} ./cmd/wiki
+          go build -ldflags="-s -w -X main.Version=${GITHUB_REF_NAME#v}" -o wiki-${{ matrix.suffix }}${{ matrix.ext }} ./cmd/wiki
 
       - name: Upload MCP server artifact
         uses: actions/upload-artifact@v7

--- a/CLI.md
+++ b/CLI.md
@@ -65,7 +65,7 @@ Set `WIKI_NO_SESSION_CACHE=1` to disable disk caching (CI, ephemeral containers,
 | `wiki compare-topic <topic>` | Compare how a topic is described across pages and surface inconsistencies |
 | `wiki translations --base ... --languages ...` | Find missing language translations for a set of base pages |
 | `wiki config` | Show or verify configuration |
-| `wiki version` | Print CLI version |
+| `wiki version` | Print CLI version (or `wiki --version`; add `--json` for `{"installed_version": ...}`) |
 
 Every command supports `--json` (machine-readable output) and `--quiet` (errors only).
 
@@ -81,9 +81,9 @@ The CLI uses typed exit codes so shell scripts can branch on the failure categor
 | 3 | Not found (HTTP 404 from wiki API) |
 | 4 | `wiki lint` found terminology issues or broken links |
 | 5 | Wiki API error (other 4xx/5xx) |
-| 6 | Auth error (HTTP 401 / 403) |
+| 6 | Auth error (HTTP 401 / 403, or bot-password login failure) |
 | 7 | Rate limit (HTTP 429) |
-| 10 | Config error |
+| 10 | Config error (e.g. missing `MEDIAWIKI_URL`) |
 
 Note: code `4` is reserved for `wiki lint` findings (existing public API), so auth errors use `6`.
 

--- a/CLI.md
+++ b/CLI.md
@@ -40,7 +40,7 @@ Set `WIKI_NO_SESSION_CACHE=1` to disable disk caching (CI, ephemeral containers,
 |---------|--------------|
 | `wiki search <query>` | Full-text search |
 | `wiki page <title>` | Read a page |
-| `wiki edit <title>` | Create or edit a page |
+| `wiki edit <title>` | Create or edit a page (add `--dry-run` to preview the write without editing or needing credentials) |
 | `wiki replace <title> --find X --replace Y` | Find and replace in a page (add `--bulk --pages` or `--bulk --category` for multi-page) |
 | `wiki lint <page>` | Check terminology and links (exit code 4 on findings) |
 | `wiki audit` | Wiki-wide health check |
@@ -68,6 +68,8 @@ Set `WIKI_NO_SESSION_CACHE=1` to disable disk caching (CI, ephemeral containers,
 | `wiki version` | Print CLI version (or `wiki --version`; add `--json` for `{"installed_version": ...}`) |
 
 Every command supports `--json` (machine-readable output) and `--quiet` (errors only).
+Under `--json`, failures are also emitted as JSON on stderr —
+`{"error": "...", "exit_code": N}` — so agents can parse them structurally.
 
 ## Exit codes
 

--- a/cmd/wiki/client.go
+++ b/cmd/wiki/client.go
@@ -25,7 +25,10 @@ func newWikiClient(cmd *cobra.Command) (*wiki.Client, error) {
 
 	cfg, err := wiki.LoadConfig()
 	if err != nil {
-		return nil, fmt.Errorf("configuration error: %w", err)
+		// Wrap as a config error so the exit code is 10 (config), not the
+		// generic 1 — this is the "missing MEDIAWIKI_URL" path an agent
+		// most often hits, and the documented contract promises 10 here.
+		return nil, configErr(fmt.Errorf("configuration error: %w", err))
 	}
 
 	// CLI logger level
@@ -51,7 +54,10 @@ func newWikiClient(cmd *cobra.Command) (*wiki.Client, error) {
 			_ = client.RestoreSession(cached) //nolint:errcheck // cache miss is non-fatal
 		}
 		if err := client.EnsureLoggedIn(context.Background()); err != nil {
-			return nil, fmt.Errorf("authentication failed: %w", err)
+			// Wrap as an auth error so a login failure resolves to exit 6
+			// even when EnsureLoggedIn returns a non-APIError (e.g. a
+			// transport failure during the bot-password handshake).
+			return nil, authErr(fmt.Errorf("authentication failed: %w", err))
 		}
 		if snapshot, err := client.SessionSnapshot(); err == nil {
 			_ = saveCachedSession(cfg.BaseURL, snapshot) //nolint:errcheck // cache write failure is non-fatal

--- a/cmd/wiki/edit.go
+++ b/cmd/wiki/edit.go
@@ -21,7 +21,12 @@ func newEditCmd() *cobra.Command {
 
   wiki edit "Page Title" --content "= Hello ="
   wiki edit "Page Title" --file page.wiki --summary "Update from file"
-  cat page.wiki | wiki edit "Page Title" --summary "Update from file"`,
+  cat page.wiki | wiki edit "Page Title" --summary "Update from file"
+
+Preview a change without writing it (and without needing credentials):
+
+  wiki edit "Page Title" --file page.wiki --dry-run
+  wiki edit "Page Title" --file page.wiki --dry-run --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: runEdit,
 	}
@@ -32,23 +37,19 @@ func newEditCmd() *cobra.Command {
 	cmd.Flags().Bool("minor", false, "Mark as minor edit")
 	cmd.Flags().Bool("bot", false, "Mark as bot edit (requires bot flag)")
 	cmd.Flags().String("section", "", "Section to edit ('new' for new section, number for existing)")
+	cmd.Flags().Bool("dry-run", false, "Resolve the content and print what would be written, then exit without editing")
 
 	return cmd
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
-	client, err := newWikiClient(cmd)
-	if err != nil {
-		return err
-	}
-	defer client.Close()
-
 	title := args[0]
 	content, _ := cmd.Flags().GetString("content")
 	summary, _ := cmd.Flags().GetString("summary")
 	minor, _ := cmd.Flags().GetBool("minor")
 	bot, _ := cmd.Flags().GetBool("bot")
 	section, _ := cmd.Flags().GetString("section")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	// If --content is empty, try --file
 	if content == "" {
@@ -64,6 +65,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 
 	// If still empty, try reading from stdin
 	if content == "" {
+		var err error
 		content, err = readStdin()
 		if err != nil {
 			return fmt.Errorf("failed to read stdin: %w", err)
@@ -71,8 +73,22 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	if content == "" {
-		return fmt.Errorf("content is required (use --content or pipe from stdin)")
+		return usageErr(fmt.Errorf("content is required (use --content, --file, or pipe from stdin)"))
 	}
+
+	// --dry-run resolves the content and reports what would be written
+	// without contacting the wiki. It deliberately skips client creation so
+	// an agent can preview a change without valid credentials — this is the
+	// safeguard the primary write previously lacked.
+	if dryRun {
+		return emitEditDryRun(cmd, title, summary, section, content, minor, bot)
+	}
+
+	client, err := newWikiClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
 
 	result, err := client.EditPage(cmd.Context(), wiki.EditPageArgs{
 		Title:   title,
@@ -110,6 +126,34 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		fmt.Printf("URL: %s\n", result.PageURL)
 	}
 
+	return nil
+}
+
+// emitEditDryRun reports what `wiki edit` would write, without performing
+// the edit. JSON under --json, otherwise a short human-readable block. The
+// content itself is summarized by byte count rather than echoed, so a large
+// page doesn't flood the output.
+func emitEditDryRun(cmd *cobra.Command, title, summary, section, content string, minor, bot bool) error {
+	if isJSON(cmd) {
+		return printJSON(map[string]any{
+			"dry_run":       true,
+			"action":        "edit",
+			"title":         title,
+			"summary":       summary,
+			"section":       section,
+			"minor":         minor,
+			"bot":           bot,
+			"content_bytes": len(content),
+		})
+	}
+	fmt.Printf("DRY RUN — no change made.\n")
+	fmt.Printf("  would edit: %s\n", title)
+	fmt.Printf("  summary:    %s\n", summary)
+	if section != "" {
+		fmt.Printf("  section:    %s\n", section)
+	}
+	fmt.Printf("  content:    %d bytes\n", len(content))
+	fmt.Printf("  minor=%t bot=%t\n", minor, bot)
 	return nil
 }
 

--- a/cmd/wiki/edit_test.go
+++ b/cmd/wiki/edit_test.go
@@ -13,6 +13,7 @@ func TestNewEditCmd(t *testing.T) {
 	cwFlagDefaultString(t, cmd, "minor", "false")
 	cwFlagDefaultString(t, cmd, "bot", "false")
 	cwFlagDefaultString(t, cmd, "section", "")
+	cwFlagDefaultString(t, cmd, "dry-run", "false")
 	// short -f alias for --file
 	if f := cmd.Flags().ShorthandLookup("f"); f == nil || f.Name != "file" {
 		t.Error("expected -f shorthand for --file")

--- a/cmd/wiki/editdryrun_test.go
+++ b/cmd/wiki/editdryrun_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestEditDryRunJSONSkipsNetwork verifies that `wiki edit --dry-run --json`
+// reports what would be written without creating a client (so it needs no
+// credentials) and returns exit 0.
+func TestEditDryRunJSONSkipsNetwork(t *testing.T) {
+	// Ensure no credentials are present so a stray network/auth path would
+	// fail loudly rather than pass by accident.
+	t.Setenv("MEDIAWIKI_URL", "")
+	t.Setenv("MEDIAWIKI_USERNAME", "")
+	t.Setenv("MEDIAWIKI_PASSWORD", "")
+
+	cmd := newEditCmd()
+	// --json is a persistent flag on root in production; add it locally so
+	// isJSON() resolves in this isolated command.
+	cmd.Flags().Bool("json", false, "")
+	cmd.SetArgs([]string{"Some Page", "--content", "= Hi =", "--dry-run", "--json"})
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+
+	err := cmd.Execute()
+
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+
+	if err != nil {
+		t.Fatalf("dry-run execute: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"dry_run": true`) {
+		t.Errorf("output = %q, want dry_run true", s)
+	}
+	if !strings.Contains(s, `"title": "Some Page"`) {
+		t.Errorf("output = %q, want title Some Page", s)
+	}
+}

--- a/cmd/wiki/exitcodes_test.go
+++ b/cmd/wiki/exitcodes_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestWrapArgsAsUsageMapsToExit2 verifies that a positional-argument
+// violation resolves to the documented usage exit code (2) rather than the
+// generic default (1).
+func TestWrapArgsAsUsageMapsToExit2(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	sub := &cobra.Command{
+		Use:  "sub",
+		Args: cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	root.AddCommand(sub)
+	wrapArgsAsUsage(root)
+
+	err := sub.Args(sub, []string{"unexpected"})
+	if err == nil {
+		t.Fatal("expected NoArgs violation to error")
+	}
+	if got := ExitCode(err); got != exitUsage {
+		t.Errorf("ExitCode = %d, want exitUsage %d", got, exitUsage)
+	}
+}
+
+// TestWrapArgsAsUsageLeavesNilValidator confirms commands that opt out of
+// argument validation (cobra's arbitrary-args default) are left untouched.
+func TestWrapArgsAsUsageLeavesNilValidator(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	sub := &cobra.Command{Use: "sub"} // no Args validator
+	root.AddCommand(sub)
+	wrapArgsAsUsage(root)
+
+	if sub.Args != nil {
+		t.Error("wrapArgsAsUsage should leave a nil Args validator untouched")
+	}
+}
+
+// TestNewWikiClientMissingURLIsConfigError locks in the config-error exit
+// code (10) for the most common agent failure: no MEDIAWIKI_URL configured.
+func TestNewWikiClientMissingURLIsConfigError(t *testing.T) {
+	t.Setenv("MEDIAWIKI_URL", "")
+	t.Setenv("MEDIAWIKI_USERNAME", "")
+	t.Setenv("MEDIAWIKI_PASSWORD", "")
+
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().Bool("verbose", false, "")
+
+	_, err := newWikiClient(cmd)
+	if err == nil {
+		t.Fatal("expected config error when MEDIAWIKI_URL is unset")
+	}
+	if got := ExitCode(err); got != exitConfig {
+		t.Errorf("ExitCode = %d, want exitConfig %d", got, exitConfig)
+	}
+}

--- a/cmd/wiki/main.go
+++ b/cmd/wiki/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -79,9 +80,26 @@ func main() {
 		if ExitCode(err) == exitDefault && strings.HasPrefix(err.Error(), "unknown command") {
 			err = usageErr(err)
 		}
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		emitError(root, err)
 		os.Exit(ExitCode(err))
 	}
+}
+
+// emitError writes a failure to stderr. Under the global --json flag it
+// emits a machine-readable {"error", "exit_code"} object so agents can parse
+// failures structurally; otherwise it prints the familiar "Error: ..." line.
+// stdout is left untouched so it stays reserved for command data.
+func emitError(root *cobra.Command, err error) {
+	if jsonOut, _ := root.PersistentFlags().GetBool("json"); jsonOut {
+		enc := json.NewEncoder(os.Stderr)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{ //nolint:errcheck // best-effort diagnostic write
+			"error":     err.Error(),
+			"exit_code": ExitCode(err),
+		})
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 }
 
 // wrapArgsAsUsage recursively replaces each command's Args validator with

--- a/cmd/wiki/main.go
+++ b/cmd/wiki/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -15,6 +16,9 @@ func main() {
 		Use:   "wiki",
 		Short: "MediaWiki CLI — search, read, edit, and audit any wiki",
 		Long:  "A command-line interface for MediaWiki wikis. Shares the same API client as mediawiki-mcp-server.",
+		// Setting Version enables the built-in `--version` flag (exit 0),
+		// complementing the `version` subcommand.
+		Version: Version,
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},
@@ -62,9 +66,38 @@ func main() {
 		newVersionCmd(),
 	)
 
+	// Map positional-argument validation errors to exit 2 (usage). Cobra's
+	// built-in Args validators return plain errors that ExitCode() can't
+	// classify; wrapping them here honors the documented exit-code contract
+	// without editing every command.
+	wrapArgsAsUsage(root)
+
 	if err := root.Execute(); err != nil {
+		// Cobra reports an unknown subcommand as a plain, unclassified
+		// error. Treat it as a usage error (exit 2) rather than the generic
+		// exit 1, matching how unknown flags are already handled.
+		if ExitCode(err) == exitDefault && strings.HasPrefix(err.Error(), "unknown command") {
+			err = usageErr(err)
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(ExitCode(err))
+	}
+}
+
+// wrapArgsAsUsage recursively replaces each command's Args validator with
+// one that wraps any validation failure as a usage error (exit 2). Commands
+// with no Args validator (cobra's default arbitrary-args) are left alone.
+func wrapArgsAsUsage(cmd *cobra.Command) {
+	for _, sub := range cmd.Commands() {
+		if inner := sub.Args; inner != nil {
+			sub.Args = func(c *cobra.Command, args []string) error {
+				if err := inner(c, args); err != nil {
+					return usageErr(err)
+				}
+				return nil
+			}
+		}
+		wrapArgsAsUsage(sub)
 	}
 }
 
@@ -72,8 +105,13 @@ func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print wiki CLI version",
-		Run: func(cmd *cobra.Command, args []string) {
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if isJSON(cmd) {
+				return printJSON(map[string]string{"installed_version": Version})
+			}
 			fmt.Printf("wiki %s\n", Version)
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
Aligns the `wiki` CLI with its own documented exit-code contract and the [Agent-Friendly CLI Checklist](https://www.level250.com/s/Agent-Friendly-CLI-Checklist.pdf) (Level 250).

## Changes
- **§5 Exit codes**: wire the defined-but-unused helpers into the real paths. Missing `MEDIAWIKI_URL` now exits **10** (was 1), login failure exits **6** even for non-APIError handshake failures (was 1), and positional-arg violations plus unknown commands exit **2** (was 1). The documented table in CLI.md was already correct — the implementation now matches it.
- **§8 Version**: add the `--version` flag (was exit 2 as an unknown flag), give `version` a `--json` form, and inject `-X main.Version` in `release.yml` so released binaries stop reporting `dev`.
- **§6 Safe side effects**: add `--dry-run` to `wiki edit`, the primary write, which previously had no preview while lesser commands did. Dry-run resolves the content and reports what would be written without contacting the wiki (no credentials needed).
- **§4 Machine-readable output**: under `--json`, failures are emitted as `{"error", "exit_code"}` on stderr instead of a bare `Error: ...` line.

## Verification
- `go test ./cmd/wiki/...` green, `golangci-lint` 0 issues, `gofmt` clean, `go build ./...` clean.
- Probed every exit code on a fresh build (10/2/2/6/0), verified release ldflags injection, offline dry-run, and JSON error output.
- New tests in `exitcodes_test.go` and `editdryrun_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)