### PR TITLE
ci: pin artifact/release actions to verified SHAs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-test-logs
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,13 @@ jobs:
           go build -ldflags="-s -w -X main.Version=${GITHUB_REF_NAME#v}" -o wiki-${{ matrix.suffix }}${{ matrix.ext }} ./cmd/wiki
 
       - name: Upload MCP server artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mediawiki-mcp-server-${{ matrix.suffix }}
           path: mediawiki-mcp-server-${{ matrix.suffix }}${{ matrix.ext }}
 
       - name: Upload wiki CLI artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wiki-${{ matrix.suffix }}
           path: wiki-${{ matrix.suffix }}${{ matrix.ext }}
@@ -77,13 +77,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: binaries
           merge-multiple: true
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: binaries/*
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Pins the artifact and release GitHub Actions to immutable commit SHAs (with a trailing version comment) for supply-chain safety. Referencing actions by mutable tags means a compromised or force-pushed tag could silently alter CI behavior; pinning to a specific commit SHA removes that risk while the comment preserves human-readable version context.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/upload-artifact` | `@v7` | `@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` |
| `actions/download-artifact` | `@v8` | `@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1` |
| `softprops/action-gh-release` | `@v3` | `@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2` |

Files touched:
- `.github/workflows/integration.yml` — `upload-artifact` (1 occurrence)
- `.github/workflows/release.yml` — `upload-artifact` (2 occurrences), `download-artifact` (1), `action-gh-release` (1)

All three pinned SHAs were verified to exist and correspond to the noted release tags. No other actions (`actions/checkout`, `actions/setup-go`, etc.) were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018S3jXgMVxkQgPgb4rWZMBT)_