### PR TITLE
feat(wiki): include page URL in search results

### DIFF
--- a/cmd/wiki/search.go
+++ b/cmd/wiki/search.go
@@ -63,10 +63,10 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	tw := table()
-	fmt.Fprintf(tw, "TITLE\tSIZE\tSNIPPET\n")
+	fmt.Fprintf(tw, "TITLE\tURL\tSIZE\tSNIPPET\n")
 	for _, hit := range result.Results {
 		snippet := truncate(stripHTML(hit.Snippet), 80)
-		fmt.Fprintf(tw, "%s\t%d\t%s\n", hit.Title, hit.Size, snippet)
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\n", hit.Title, hit.URL, hit.Size, snippet)
 	}
 	_ = tw.Flush()
 

--- a/cmd/wiki/searchread.go
+++ b/cmd/wiki/searchread.go
@@ -76,6 +76,10 @@ func printOtherHits(hits []wiki.SearchHit) {
 	}
 	fmt.Printf("\nOther hits:\n")
 	for _, h := range hits {
-		fmt.Printf("  %s\n", h.Title)
+		if h.URL != "" {
+			fmt.Printf("  %s  %s\n", h.Title, h.URL)
+		} else {
+			fmt.Printf("  %s\n", h.Title)
+		}
 	}
 }

--- a/wiki/search.go
+++ b/wiki/search.go
@@ -72,9 +72,11 @@ func (c *Client) Search(ctx context.Context, args SearchArgs) (SearchResult, err
 		if item == nil {
 			continue
 		}
+		title := getString(item["title"])
 		hit := SearchHit{
 			PageID:  getInt(item["pageid"]),
-			Title:   getString(item["title"]),
+			Title:   title,
+			URL:     c.pageURL(ctx, title),
 			Snippet: stripHTMLTags(getString(item["snippet"])),
 			Size:    getInt(item["size"]),
 		}

--- a/wiki/types.go
+++ b/wiki/types.go
@@ -66,6 +66,7 @@ type SearchResult struct {
 type SearchHit struct {
 	PageID  int    `json:"page_id"`
 	Title   string `json:"title"`
+	URL     string `json:"url,omitempty"`
 	Snippet string `json:"snippet"`
 	Size    int    `json:"size"`
 }


### PR DESCRIPTION
Search results now include the page URL for each hit, constructed from the wiki's ArticlePath (via siteinfo) with a fallback to index.php.

Changes:
- Added `URL` field to `SearchHit` struct
- `Search()` populates URL via the existing `pageURL()` method
- CLI `wiki search` table output now shows a URL column
- `wiki search-read` "Other hits" also display URLs
- JSON output includes the new `url` field (omitted when empty)
