### PR TITLE
feat(wiki): include page URL in search results (merges #98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MediaWiki MCP Server are documented here.
 
+## [Unreleased]
+
+### Added
+- **Page URL in search results** (#98, thanks @strk). `SearchHit` gains a `url` field built from the wiki's `ArticlePath` via siteinfo, falling back to the universal `index.php?title=` form when siteinfo is unavailable. Siteinfo is cached, so a search costs at most one extra API call. `wiki search` shows a `URL` column, `wiki search-read` prints the URL alongside each other hit, and JSON output carries `url` (omitted when empty).
+
 ## [1.34.0] - 2026-07-22
 
 ### Added

--- a/cmd/wiki/search.go
+++ b/cmd/wiki/search.go
@@ -63,10 +63,10 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	tw := table()
-	fmt.Fprintf(tw, "TITLE\tSIZE\tSNIPPET\n")
+	fmt.Fprintf(tw, "TITLE\tURL\tSIZE\tSNIPPET\n")
 	for _, hit := range result.Results {
 		snippet := truncate(stripHTML(hit.Snippet), 80)
-		fmt.Fprintf(tw, "%s\t%d\t%s\n", hit.Title, hit.Size, snippet)
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\n", hit.Title, hit.URL, hit.Size, snippet)
 	}
 	_ = tw.Flush()
 

--- a/cmd/wiki/searchread.go
+++ b/cmd/wiki/searchread.go
@@ -76,6 +76,10 @@ func printOtherHits(hits []wiki.SearchHit) {
 	}
 	fmt.Printf("\nOther hits:\n")
 	for _, h := range hits {
-		fmt.Printf("  %s\n", h.Title)
+		if h.URL != "" {
+			fmt.Printf("  %s  %s\n", h.Title, h.URL)
+		} else {
+			fmt.Printf("  %s\n", h.Title)
+		}
 	}
 }

--- a/wiki/search.go
+++ b/wiki/search.go
@@ -72,9 +72,11 @@ func (c *Client) Search(ctx context.Context, args SearchArgs) (SearchResult, err
 		if item == nil {
 			continue
 		}
+		title := getString(item["title"])
 		hit := SearchHit{
 			PageID:  getInt(item["pageid"]),
-			Title:   getString(item["title"]),
+			Title:   title,
+			URL:     c.pageURL(ctx, title),
 			Snippet: stripHTMLTags(getString(item["snippet"])),
 			Size:    getInt(item["size"]),
 		}

--- a/wiki/search.go
+++ b/wiki/search.go
@@ -51,7 +51,7 @@ func (c *Client) Search(ctx context.Context, args SearchArgs) (SearchResult, err
 		totalHits = getInt(searchInfo["totalhits"])
 	}
 
-	results := parseSearchHits(getSlice(query["search"]))
+	results := c.parseSearchHits(ctx, getSlice(query["search"]))
 
 	result := SearchResult{
 		Query:     args.Query,
@@ -84,17 +84,21 @@ func buildSearchParams(args SearchArgs) url.Values {
 	return params
 }
 
-// parseSearchHits converts raw API search entries into SearchHit values
-func parseSearchHits(searchResults []any) []SearchHit {
+// parseSearchHits converts raw API search entries into SearchHit values.
+// Each hit carries the human-readable page URL built from the wiki's
+// ArticlePath; siteinfo is cached, so this costs at most one extra request.
+func (c *Client) parseSearchHits(ctx context.Context, searchResults []any) []SearchHit {
 	results := make([]SearchHit, 0, len(searchResults))
 	for _, sr := range searchResults {
 		item := getMap(sr)
 		if item == nil {
 			continue
 		}
+		title := getString(item["title"])
 		results = append(results, SearchHit{
 			PageID:  getInt(item["pageid"]),
-			Title:   getString(item["title"]),
+			Title:   title,
+			URL:     c.pageURL(ctx, title),
 			Snippet: stripHTMLTags(getString(item["snippet"])),
 			Size:    getInt(item["size"]),
 		})

--- a/wiki/search_test.go
+++ b/wiki/search_test.go
@@ -1044,3 +1044,97 @@ func TestCompareTopic_NoResults(t *testing.T) {
 		t.Errorf("Expected no page mentions, got %d", len(result.PageMentions))
 	}
 }
+
+// searchHitURLServer returns a mock wiki that answers a search query with a
+// single hit. When articlePath is non-empty, siteinfo advertises it so the
+// pretty URL form is used; otherwise siteinfo is unusable and pageURL falls
+// back to the index.php form.
+func searchHitURLServer(t *testing.T, title, articlePath string) *httptest.Server {
+	t.Helper()
+	return mockMediaWikiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.FormValue("meta") == "siteinfo" {
+			general := map[string]interface{}{}
+			if articlePath != "" {
+				general["server"] = "https://wiki.example.com"
+				general["articlepath"] = articlePath
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"query": map[string]interface{}{"general": general},
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"query": map[string]interface{}{
+				"searchinfo": map[string]interface{}{"totalhits": float64(1)},
+				"search": []interface{}{
+					map[string]interface{}{
+						"pageid":  float64(7),
+						"title":   title,
+						"snippet": "some <b>content</b>",
+						"size":    float64(120),
+					},
+				},
+			},
+		})
+	})
+}
+
+func TestSearch_HitURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		title       string
+		articlePath string
+		want        string
+	}{
+		{
+			name:        "pretty article path",
+			title:       "Test Page",
+			articlePath: "/wiki/$1",
+			want:        "https://wiki.example.com/wiki/Test_Page",
+		},
+		{
+			name:        "subpage slash preserved",
+			title:       "User:Alice/Sandbox",
+			articlePath: "/wiki/$1",
+			want:        "https://wiki.example.com/wiki/User:Alice/Sandbox",
+		},
+		{
+			name:  "falls back to index.php when siteinfo is unusable",
+			title: "Test Page",
+			want:  "index.php?title=Test_Page",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := searchHitURLServer(t, tt.title, tt.articlePath)
+			defer server.Close()
+
+			client := createMockClient(t, server)
+			defer client.Close()
+
+			result, err := client.Search(context.Background(), SearchArgs{Query: "test"})
+			if err != nil {
+				t.Fatalf("Search failed: %v", err)
+			}
+			if len(result.Results) != 1 {
+				t.Fatalf("len(Results) = %d, want 1", len(result.Results))
+			}
+
+			got := result.Results[0].URL
+			if tt.articlePath != "" {
+				if got != tt.want {
+					t.Errorf("Results[0].URL = %q, want %q", got, tt.want)
+				}
+				return
+			}
+			if !strings.HasSuffix(got, tt.want) {
+				t.Errorf("Results[0].URL = %q, want suffix %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/wiki/types.go
+++ b/wiki/types.go
@@ -66,6 +66,7 @@ type SearchResult struct {
 type SearchHit struct {
 	PageID  int    `json:"page_id"`
 	Title   string `json:"title"`
+	URL     string `json:"url,omitempty"`
 	Snippet string `json:"snippet"`
 	Size    int    `json:"size"`
 }


### PR DESCRIPTION
Lands @strk's #98 with the conflict against `main` resolved.

## Why this branch instead of merging #98 directly

#98 was opened before #99 (Code Health 10.0), which extracted the search-hit parsing into a free `parseSearchHits()` function. The two collide in `wiki/search.go`, so #98 shows as `CONFLICTING` and its green checks reflect its own head, not a merge with current `main`.

Resolution keeps #99's extraction and gives it a client receiver (`c.parseSearchHits(ctx, ...)`) so it can populate the URL, rather than reverting to the inline loop.

## On top of #98

- `TestSearch_HitURL` — pretty `ArticlePath` form, subpage slash preservation (`User:Alice/Sandbox` stays unescaped), and the `index.php` fallback when siteinfo is unusable. #98 shipped no test for the new field.
- CHANGELOG `[Unreleased]` entry, per the convention in #97 and #93.

## Notes

- `pageURL()` goes through cached `GetWikiInfo`, so a search costs at most one extra API call regardless of hit count.
- `url,omitempty` keeps JSON and MCP responses unchanged when the URL cannot be built.
- Cosmetic, non-blocking: `wiki search` now prints TITLE + full URL + SIZE + 80-char snippet in one tabwriter row, which wraps on an 80-column terminal.

Verified locally on the merged tree: `go test -race ./...` passes for all packages, `golangci-lint run ./...` reports 0 issues.

Closes #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)