### PR TITLE
deps: bump google.golang.org/grpc to v1.82.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,6 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Closes Dependabot alert [#2](https://github.com/olgasafonova/mediawiki-mcp-server/security/dependabot/2).

## Advisory

| | |
|---|---|
| GHSA | [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) |
| Severity | High |
| Summary | gRPC-Go: xDS RBAC and HTTP/2 vulnerabilities |
| Vulnerable range | `< 1.82.1` |
| Patched | `1.82.1` |

## Change

`google.golang.org/grpc` v1.81.1 to v1.82.1 in `go.mod`, plus the matching `go.sum` hashes. Three lines across two files; `go mod tidy` moved nothing else.

The package is a transitive runtime dependency, pulled in by `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0`. Pinning it in `go.mod` keeps it above the vulnerable range regardless of when otel updates its own constraint.

## Exposure

This server does not use gRPC directly. The advisory covers xDS RBAC and HTTP/2 server paths that are not reachable from an OTel HTTP trace exporter, so practical exposure is low. The bump is still the right fix; it just is not urgent.

## Verification

- `go build ./...` exit 0
- `go test ./...` exit 0, 8/8 packages ok, no failures
- `go mod verify` all modules verified
- `go list -m google.golang.org/grpc` resolves to v1.82.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)