### PR TITLE
chore(deslop): migrate baseline to schema v3 (fingerprints)

### DIFF
--- a/.deslop-baseline.json
+++ b/.deslop-baseline.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": 1,
+  "schema_version": 3,
   "generated_at": "2026-06-29T09:12:39Z",
-  "deslop_version": "2.1.0",
+  "deslop_version": "2.3.0",
   "scores": {
     "file_health": 100.0,
     "test_coverage": 100.0,
@@ -15,80 +15,106 @@
     {
       "detector": "file_health",
       "severity": "critical",
-      "key": "wiki/write_test.go",
-      "summary": "wiki/write_test.go (1,855 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "key": "wiki/client_test.go",
+      "summary": "wiki/client_test.go (1,592 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:bbf7bfe000843c8514a985b70d4fecbea0f4cf1a6169a5a24f40c47ad85f5442",
+      "id": "bbf7"
     },
     {
       "detector": "file_health",
       "severity": "critical",
-      "key": "wiki/client_test.go",
-      "summary": "wiki/client_test.go (1,592 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "key": "wiki/write_test.go",
+      "summary": "wiki/write_test.go (1,855 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:63d5e2ae43d749d8eb83e37047d19f2b2c96f8e57f3c8390390d3e8618a21b37",
+      "id": "63d5"
     },
     {
       "detector": "file_health",
       "severity": "high",
       "key": "wiki/api_test.go",
-      "summary": "wiki/api_test.go (1,062 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
-    },
-    {
-      "detector": "file_health",
-      "severity": "high",
-      "key": "wiki/search_test.go",
-      "summary": "wiki/search_test.go (1,046 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/api_test.go (1,062 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:fc6eaf34345c81b23563daf4fc5484658a20f7c57383b74d8ccaaecf9a714752",
+      "id": "fc6e"
     },
     {
       "detector": "file_health",
       "severity": "high",
       "key": "wiki/quality_test.go",
-      "summary": "wiki/quality_test.go (987 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/quality_test.go (987 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:b785af7c7cd0a3bf8941922dc6caf72989be37c73a142b6fcd0097608808149e",
+      "id": "b785"
+    },
+    {
+      "detector": "file_health",
+      "severity": "high",
+      "key": "wiki/search_test.go",
+      "summary": "wiki/search_test.go (1,046 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:702ee1953368ab012f2759af405a5d8bca4dbd17fd87cd2c0a3581fad1cd7d87",
+      "id": "702e"
     },
     {
       "detector": "file_health",
       "severity": "warning",
       "key": "wiki/audit_test.go",
-      "summary": "wiki/audit_test.go (542 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/audit_test.go (542 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:ba3fd977bfda0b31d0fd00e32ccfa8cca3f3305f0201bde23c6ab6ef61e2a794",
+      "id": "ba3f"
     },
     {
       "detector": "file_health",
       "severity": "warning",
       "key": "wiki/history_test.go",
-      "summary": "wiki/history_test.go (645 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/history_test.go (645 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:8c1841e0645b1082335393b3e0e75898a624c69fd71d156cdce4872ddd5d4a91",
+      "id": "8c18"
     },
     {
       "detector": "file_health",
       "severity": "warning",
       "key": "wiki/links_test.go",
-      "summary": "wiki/links_test.go (794 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/links_test.go (794 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:23f411c2364ad43cd49e3b0040f71da91973284a0da2e31a50ab68b289cd554a",
+      "id": "23f4"
     },
     {
       "detector": "file_health",
       "severity": "warning",
       "key": "wiki/pageinfo_test.go",
-      "summary": "wiki/pageinfo_test.go (521 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/pageinfo_test.go (521 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:a413659acb67073aec5af8fc343d8132828eebd9f8aac37fb1922d3966a48211",
+      "id": "a413"
     },
     {
       "detector": "file_health",
       "severity": "warning",
       "key": "wiki/security_test.go",
-      "summary": "wiki/security_test.go (800 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/security_test.go (800 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:32f8717b04a03680d51f63fbea2f9c7e60ddc0c230499a066c6bf791fe5ee715",
+      "id": "32f8"
     },
     {
       "detector": "file_health",
       "severity": "warning",
       "key": "wiki/similarity_test.go",
-      "summary": "wiki/similarity_test.go (738 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)"
+      "summary": "wiki/similarity_test.go (738 LOC) \u2014 large test file (accepted; idiomatic table-driven tests)",
+      "fingerprint": "sha256:9f1ba79e77aca1dd7bcca918a563ac513bc89bb26fd45e9245e30653a4a4bcb7",
+      "id": "9f1b"
     },
     {
       "detector": "structural_quality",
       "severity": "warning",
       "key": "god_package:cmd/wiki",
-      "summary": "cmd/wiki/ has 31 source files (>20) \u2014 ACCEPTED: flat structure is idiomatic for a CLI command set; subpackaging would add import-cycle risk without improving design"
+      "summary": "cmd/wiki/ has 31 source files (>20) \u2014 ACCEPTED: flat structure is idiomatic for a CLI command set; subpackaging would add import-cycle risk without improving design",
+      "fingerprint": "sha256:ebc5832c4def4ce94f183758d7f151ae1f315adb7132bad07629e407e472b718",
+      "id": "ebc5"
     },
     {
       "detector": "structural_quality",
       "severity": "warning",
       "key": "god_package:wiki",
-      "summary": "wiki/ has 45 source files (>20) \u2014 ACCEPTED: flat structure is idiomatic for a wiki-API client package; subpackaging would add import-cycle risk without improving design"
+      "summary": "wiki/ has 45 source files (>20) \u2014 ACCEPTED: flat structure is idiomatic for a wiki-API client package; subpackaging would add import-cycle risk without improving design",
+      "fingerprint": "sha256:0c514b7eea10450f43e933af27779047a76b6b07e7332388943de272759336bd",
+      "id": "0c51"
     }
   ]
 }


### PR DESCRIPTION
Carries `.deslop-baseline.json` to schema v3, adding a content fingerprint per finding.

Before this, a baselined finding was suppressed forever: regression mode diffed on the `key` string alone, and the `summary` field carrying the actual measurement was never compared. A fingerprint hashes the slice the detector actually judged, so an ack expires by itself the moment that slice moves.

**13 findings migrated, 0 dropped. 5 had already drifted silently:**

| Finding | Baseline | Now |
|---|---|---|
| `wiki/write_test.go` | 1,855 LOC | 2,019 |
| `wiki/api_test.go` | 1,062 LOC | 1,065 |
| `wiki/search_test.go` | 1,046 LOC | 1,140 |
| `god_package:cmd/wiki` | 31 source files | 33 |
| `god_package:wiki` | 45 source files | 50 |

Skill change: olgasafonova/claude-code-config `feat(deslop): fingerprint-as-ack-lifetime baselines (schema v3, exkk)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)