### PR TITLE
feat(http): serve MCP 2026-07-28 by making Streamable HTTP stateless

### DIFF
--- a/main_httpserver.go
+++ b/main_httpserver.go
@@ -85,9 +85,15 @@ func runHTTPServer(cfg httpServerConfig) {
 // only intentionally-public routes (/health liveness, server-card discovery)
 // are wired separately on the outer mux in buildHTTPMux.
 func newSecuredHandler(cfg httpServerConfig, allowedOrigins []string) *SecurityMiddleware {
+	// Stateless is required to serve protocol revision 2026-07-28: without it
+	// the transport rejects every request at that version with HTTP 400, with
+	// server/discover the only exemption. Safe here because the same
+	// *mcp.Server is returned for every request, so there is no per-session
+	// state to lose. Session IDs are ignored and DELETE returns 405, per the
+	// spec (SEP-2567).
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return cfg.Server
-	}, nil)
+	}, &mcp.StreamableHTTPOptions{Stateless: true})
 
 	inner := http.NewServeMux()
 	inner.Handle("/metrics", promhttp.Handler())
@@ -118,7 +124,7 @@ func buildHTTPMux(cfg httpServerConfig, securedHandler http.Handler) *http.Serve
 	cfg.Card.Remotes = []servercard.Remote{{
 		Type:                      "streamable-http",
 		URL:                       "/",
-		SupportedProtocolVersions: []string{"2025-06-18"},
+		SupportedProtocolVersions: []string{"2026-07-28", "2025-11-25", "2025-06-18"},
 	}}
 	mux.Handle(servercard.WellKnownPath, servercard.Handler(cfg.Card))
 

--- a/main_security.go
+++ b/main_security.go
@@ -293,8 +293,12 @@ func setCORSHeaders(w http.ResponseWriter, r *http.Request, allowedOrigins map[s
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 	}
 
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Mcp-Session-Id")
+	// The stateless transport has no sessions to terminate, so DELETE and
+	// Mcp-Session-Id are gone. Mcp-Method and Mcp-Name are required on POST
+	// from protocol revision 2026-07-28 (SEP-2243), so browser clients need
+	// them allowed through preflight.
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Mcp-Protocol-Version, Mcp-Method, Mcp-Name")
 	w.Header().Set("Access-Control-Max-Age", "86400")
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -295,4 +296,58 @@ func TestHealthOpenAuxSecuredViaMux(t *testing.T) {
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("/tools via mux without token = %d, want %d", w.Code, http.StatusUnauthorized)
 	}
+}
+
+// TestNewSecuredHandler_ServesProtocol20260728 pins the reason the Streamable
+// HTTP handler is constructed with Stateless: true. Without it the transport
+// rejects every >= 2026-07-28 request with HTTP 400 ("only supported on
+// stateless HTTP servers"), which no build or lint pass can detect. Verified by
+// ablation: both subtests fail when the option is removed.
+//
+// tools/list, not server/discover: a stateful handler exempts server/discover so
+// clients can still read supported versions off DiscoverResult, so probing
+// discover would pass either way and pin nothing.
+func TestNewSecuredHandler_ServesProtocol20260728(t *testing.T) {
+	logger := testLogger()
+	cfg := httpServerConfig{Server: newMCPServer(logger), Logger: logger}
+	secured := newSecuredHandler(cfg, nil)
+
+	t.Run("tools/list is answered at 2026-07-28", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{` +
+			`"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+			`"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1"},` +
+			`"io.modelcontextprotocol/clientCapabilities":{}}}}`
+
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+		req.RemoteAddr = "192.168.1.1:12345"
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		// SEP-2243: a request carrying io.modelcontextprotocol/protocolVersion in
+		// _meta MUST also send the matching header, or the transport rejects it
+		// with -32020 HeaderMismatch.
+		req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+		req.Header.Set("Mcp-Method", "tools/list")
+
+		w := httptest.NewRecorder()
+		secured.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+		}
+		if got := w.Body.String(); !strings.Contains(got, `"resultType":"complete"`) {
+			t.Errorf("response does not carry resultType complete: %s", got)
+		}
+	})
+
+	t.Run("DELETE is rejected because there are no sessions to terminate", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/", nil)
+		req.RemoteAddr = "192.168.1.1:12345"
+
+		w := httptest.NewRecorder()
+		secured.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d, want 405", w.Code)
+		}
+	})
 }


### PR DESCRIPTION
Wave 1 of the MCP `2026-07-28` migration. Follows the go-sdk v1.7.0 bump, which is already on `main`.

## What changes

`mcp.NewStreamableHTTPHandler(fn, nil)` becomes `mcp.NewStreamableHTTPHandler(fn, &mcp.StreamableHTTPOptions{Stateless: true})`.

## Why it is needed

I checked the SDK source rather than trusting the release notes, and the mechanism is stricter than "negotiates down". In `streamable.go`, a **stateful** handler rejects any request at `>= 2026-07-28` with **HTTP 400**:

```
Bad Request: protocol version "2026-07-28" is only supported on
stateless HTTP servers (set StreamableHTTPOptions.Stateless = true)
```

`server/discover` is explicitly exempt, so clients can still read supported versions off `DiscoverResult`. Everything else, including `tools/list` and `tools/call`, gets the 400.

## Why it is safe here

- The same `*mcp.Server` was already returned for every request, so there is no per-session state to lose.
- No `EventStore`, `Last-Event-ID`, or resumability anywhere in the tree. This revision removes all three, so there is nothing to migrate.
- Legacy clients are unaffected: they keep negotiating `2025-11-25` through the normal `initialize` path.

## Consequences, per SEP-2567

Session IDs are ignored, and `GET` and `DELETE` return 405. CORS is updated to match: `DELETE` and `Mcp-Session-Id` dropped, `Mcp-Protocol-Version`, `Mcp-Method` and `Mcp-Name` allowed, since SEP-2243 requires those on POST from this revision. Browser clients would otherwise fail preflight.

`MCPGODEBUG=allowsessionsinstateless=1` would restore the old session handling. It is deliberately not used, since it is removed in v1.9.0.

## Test

Adds a test that fails when the option is removed, confirmed by ablation:

```
WITH Stateless:     PASS  tools/list at 2026-07-28
                    PASS  DELETE returns 405
Stateless removed:  FAIL  status = 400, want 200
                    FAIL  status = 400, want 405
```

It probes `tools/list`, not `server/discover`. My first draft probed discover and **passed on a stateful handler**, pinning nothing, because of the exemption above. Worth knowing for anyone writing a similar test.

## Discovered while doing this

The `x-mcp-header` work I had filed as an optional Wave 2 item is not optional for HTTP. A request carrying `io.modelcontextprotocol/protocolVersion` in `_meta` **must** also send a matching `Mcp-Protocol-Version` header, or the transport returns `-32020 HeaderMismatch`. That is why the header appears in both the test and the CORS allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also fixed

The server card advertised `SupportedProtocolVersions: ["2025-06-18"]`, three revisions stale and now actively wrong about this server. Updated to `["2026-07-28", "2025-11-25", "2025-06-18"]`.
