### PR TITLE
feat(cache): advertise a 30-minute ttlMs on cacheable results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.2
 require (
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
+	github.com/olgasafonova/mcp-cache-go v0.1.0
 	github.com/olgasafonova/mcp-servercard-go v0.3.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6
 github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/olgasafonova/mcp-cache-go v0.1.0 h1:JAyn1obQG4he5WJLqSp3bjblKMF9lXVuOc3lgW2NsLs=
+github.com/olgasafonova/mcp-cache-go v0.1.0/go.mod h1:3eVVOwpy3vE7CV4nCSAmbJlBYYADst1Rf+cc0ByMN/A=
 github.com/olgasafonova/mcp-servercard-go v0.3.0 h1:v2ptLFSSw0434nBZp5yI4Ya1xHajUE8gy2etkKQ531Y=
 github.com/olgasafonova/mcp-servercard-go v0.3.0/go.mod h1:Xdp3NlQ7vH3W2nwJY1IX54lo639PmLBBxbC+Hwvj6Ig=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=

--- a/main.go
+++ b/main.go
@@ -11,8 +11,10 @@ import (
 	"os/signal"
 	"runtime/debug"
 	"syscall"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/olgasafonova/mcp-cache-go/mcpcache"
 	"github.com/olgasafonova/mcp-servercard-go/servercard"
 	"github.com/olgasafonova/mediawiki-mcp-server/converter"
 	"github.com/olgasafonova/mediawiki-mcp-server/tools"
@@ -296,7 +298,7 @@ func resolveAuthToken(flagToken string) string {
 
 // newMCPServer constructs the MCP server with the tool-selection instructions.
 func newMCPServer(logger *slog.Logger) *mcp.Server {
-	return mcp.NewServer(&mcp.Implementation{
+	server := mcp.NewServer(&mcp.Implementation{
 		Name:    ServerName,
 		Version: ServerVersion,
 	}, &mcp.ServerOptions{
@@ -307,6 +309,29 @@ func newMCPServer(logger *slog.Logger) *mcp.Server {
 		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 		Instructions: serverInstructions,
 	})
+
+	// SEP-2549 requires ttlMs and cacheScope on every cacheable result, but the
+	// SDK's setDefaultCacheableValues() sets cacheScope only and leaves ttlMs at
+	// 0, which the spec reads as "immediately stale". There is no ServerOptions
+	// knob for it, so a receiving middleware is the only way to advertise a real
+	// TTL. The SDK sets its defaults inside the method handler, so receiving
+	// middleware runs after and this stamp wins.
+	//
+	// Attached here rather than in runStdioServer or newSecuredHandler because
+	// main builds one *mcp.Server and hands it to whichever transport is
+	// selected. Attaching in a transport branch would leave the other unstamped.
+	//
+	// Thirty minutes rather than an hour: this server is under active
+	// development, so its tool set turns over faster than the read-only readers
+	// in the portfolio.
+	server.AddReceivingMiddleware(mcpcache.Middleware(mcpcache.Config{
+		TTLs: map[string]time.Duration{
+			mcpcache.MethodListTools: 30 * time.Minute,
+			mcpcache.MethodDiscover:  30 * time.Minute,
+		},
+	}))
+
+	return server
 }
 
 // registerToolsAndResources registers all wiki tools, the converter tool, and

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -350,4 +351,72 @@ func TestNewSecuredHandler_ServesProtocol20260728(t *testing.T) {
 			t.Errorf("status = %d, want 405", w.Code)
 		}
 	})
+}
+
+// TestToolsListAdvertisesCacheTTL pins that newMCPServer attaches the ttlMs
+// stamping middleware. Without it the SDK leaves ttlMs at 0, which the spec
+// reads as "immediately stale", so every client re-fetches the tool list on
+// every turn. Verified by ablation: remove the AddReceivingMiddleware call in
+// newMCPServer and this fails with "ttlMs = 0, want 1800000".
+//
+// Driven through newSecuredHandler rather than an in-memory stdio session on
+// purpose. This server serves both transports from one *mcp.Server, and a
+// stdio-only assertion would pass while the HTTP path went unstamped.
+func TestToolsListAdvertisesCacheTTL(t *testing.T) {
+	logger := testLogger()
+	cfg := httpServerConfig{Server: newMCPServer(logger), Logger: logger}
+	secured := newSecuredHandler(cfg, nil)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{` +
+		`"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+		`"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1"},` +
+		`"io.modelcontextprotocol/clientCapabilities":{}}}}`
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.RemoteAddr = "192.168.1.1:12345"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Method", "tools/list")
+
+	w := httptest.NewRecorder()
+	secured.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	const wantTTL = 1800000 // thirty minutes, matching newMCPServer
+	got := extractTTLMs(t, w.Body.String())
+	if got != wantTTL {
+		t.Errorf("ttlMs = %d, want %d", got, wantTTL)
+	}
+}
+
+// extractTTLMs pulls ttlMs off a tools/list response. The handler may answer as
+// plain JSON or as an SSE frame depending on the Accept header, so scan for the
+// data payload rather than assuming one shape.
+func extractTTLMs(t *testing.T, raw string) int {
+	t.Helper()
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimPrefix(strings.TrimSpace(line), "data: ")
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var envelope struct {
+			Result struct {
+				TTLMs *int `json:"ttlMs"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			continue
+		}
+		if envelope.Result.TTLMs != nil {
+			return *envelope.Result.TTLMs
+		}
+	}
+
+	t.Fatalf("no ttlMs field found in response: %s", raw)
+	return 0
 }


### PR DESCRIPTION
Part of the MCP `2026-07-28` migration, bead `claude-code-config-4fc4.2`. Fifth consumer of `mcp-cache-go` after gleif (#62), ratatoskr (#22), ridge (#46) and nordic-registry (#55).

## Why

SEP-2549 requires `ttlMs` and `cacheScope` on every cacheable result. The SDK's `setDefaultCacheableValues()` sets `cacheScope` only and leaves `ttlMs` at `0`, which the spec reads as *immediately stale* — so a compliant client caches nothing and re-fetches the full tool list every turn. There is no `ServerOptions` knob for TTL, so `AddReceivingMiddleware` is the only way to stamp one. The SDK sets its defaults *inside* the method handler, so receiving middleware runs after and this stamp wins.

## Where it attaches, and why it matters here

In `newMCPServer`, not in a transport branch. `main` builds one `*mcp.Server` and hands it to either `runHTTPServer` or `runStdioServer` — attaching inside one branch would leave the other unstamped. This server serves **both** stdio and stateless Streamable HTTP (Wave 1, #108), so that is a live failure mode, not a hypothetical.

TTL is 30 minutes rather than the hour used for the read-only readers: this server is under active development, so its tool set turns over faster.

## Verification

`TestToolsListAdvertisesCacheTTL` drives `newSecuredHandler` rather than an in-memory stdio session, on purpose — a stdio-only assertion would pass while the HTTP path went unstamped.

- **Ablation:** removing the `AddReceivingMiddleware` call fails the test with `ttlMs = 0, want 1800000`. Run and confirmed, not assumed.
- `go build ./...`, `go test -race ./...`, `golangci-lint run ./...` all green.
- `go mod tidy` run and `go.mod`/`go.sum` committed; the dependency is recorded as direct, not `// indirect`.

Live-binary probe over `mcp.CommandTransport` to follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)