### PR TITLE
chore(deps): raise toolchain floor to go1.26.5 for GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/olgasafonova/mediawiki-mcp-server
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.5
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.62.0


### PR DESCRIPTION
Closes the last place `GO-2026-5856` could still reach a build of this repo.

## Scope check first

`govulncheck` originally flagged `GO-2026-5856` (CVE-2026-42505, Encrypted Client Hello privacy leak in `crypto/tls`) as **reachable** here. That result came from a local `go1.26.4` toolchain, not from CI. Verified against what actually builds this repo:

| Toolchain source | Resolves to | Affected |
|---|---|---|
| `.github/workflows/*` (`go-version: '1.26'`) | go1.26.5 | no — 1.26 branch fix **is** 1.26.5 |
| `go.mod` `toolchain` directive | **go1.26.2** | yes |

So CI was never shipping a vulnerable binary. The floating `'1.26'` spec picks up the patch release automatically.

## What this changes

The `toolchain` directive pinned `go1.26.2`. Go uses the local toolchain when it is newer, so this only bites a contributor whose local Go predates 1.26.2 — Go then downloads *exactly* `go1.26.2` and builds against the vulnerable `crypto/tls`. Raising the floor to `go1.26.5` closes that path.

One line. `go mod tidy` is a no-op beyond it, so the Go Mod Tidy Check stays green. `go build`, `go vet`, and the full suite pass locally on go1.26.5.

`govulncheck ./...` against `main` on go1.26.5 now reports **No vulnerabilities found** (grpc reached v1.83.0 via the Dependabot bump in #112, clearing GO-2026-6061 as well).