### PR TITLE
ci: add all-checks aggregator so matrix jobs can be required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,35 @@ jobs:
             ext=".exe"
           fi
           go build -ldflags="-s -w" -o mediawiki-mcp-server-${{ matrix.goos }}-${{ matrix.goarch }}${ext} .
+
+  # Stable aggregate context. Required-status-check lists name this job and
+  # never a matrix leg: a leg's context embeds its matrix values ("Test (Go
+  # 1.26)", "Build (linux/arm64)"), so changing the Go version or the build
+  # matrix renames the context and branch protection then waits forever for a
+  # name nothing emits. That is not hypothetical - it blocked every PR merge on
+  # miro-mcp-server from 23-12-2025 to 26-08-2026.
+  #
+  # `if: always()` is what makes the assertion below possible. Without it this
+  # job is skipped whenever a dependency fails, is skipped, or is cancelled, and
+  # GitHub counts a skipped required check as satisfied. With it the job always
+  # runs, and the step fails on any dependency result that is not exactly
+  # "success" - failure, skipped and cancelled all fail the aggregate. For a
+  # matrix dependency, needs.<job>.result is the roll-up over every leg.
+  all-checks:
+    name: all-checks
+    if: always()
+    needs: [lint, test, security, go-mod-tidy, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert every dependency succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          printf '%s\n' "$NEEDS"
+          bad=$(printf '%s' "$NEEDS" | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"')
+          if [ -n "$bad" ]; then
+            echo "::error::Aggregate failed; these jobs did not succeed:"
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+          echo "All dependencies succeeded."


### PR DESCRIPTION
Closes `claude-code-config-5mc0`.

## The bug this prevents

A required status check that names a matrix leg embeds a value that changes when the matrix does. GitHub then waits forever for a context nothing will emit, and PRs sit `BLOCKED` with green CI.

Receipt: `miro-mcp-server`'s `protect-main` ruleset required bare `build` and `lint` while CI emitted five `build (os, arch)` legs and `golangci`. PR merges were blocked from 23-12-2025 to 26-08-2026. PR #98 had all 8 checks SUCCESS and was closed unmerged.

Branch protection set on 26-08-2026 therefore excluded every matrix-named context, leaving the required lists **safe but incomplete** — test coverage living only in a matrix leg gated nothing.

## Two load-bearing details

**`if: always()` is required.** Without it, a failed or skipped dependency makes this job itself *skipped*, and GitHub counts a skipped required check as **satisfied**. That is the silent-degradation hole. `always()` forces the job to run so it can judge.

**The filter is an allowlist of one value**, `result != "success"`, not a denylist of `"failure"`. So `failure`, `skipped` and `cancelled` all fail the aggregate. For a matrix dependency, `needs.<job>.result` is the roll-up across every leg.

Verified against synthetic `toJSON(needs)` payloads:

| Dependency state | Result |
|---|---|
| all success | exit 0 |
| one failure | exit 1 |
| one skipped | exit 1 |
| one cancelled | exit 1 |

## Sequencing

The `all-checks` context does not exist on GitHub until a run emits it on the default branch. It cannot be added to any required-check list until after this merges and a run completes on `main`. Adding it earlier reproduces the exact bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)